### PR TITLE
feat: Add idempotent key

### DIFF
--- a/src/main/java/com/resend/core/net/IHttpClient.java
+++ b/src/main/java/com/resend/core/net/IHttpClient.java
@@ -3,6 +3,8 @@ package com.resend.core.net;
 import com.resend.core.exception.ResendException;
 import okhttp3.MediaType;
 
+import java.util.Map;
+
 /**
  * An interface representing an HTTP client for performing HTTP requests and receiving responses.
  *
@@ -21,4 +23,17 @@ public interface IHttpClient<T> {
      * @return An {@link AbstractHttpResponse} representing the response from the server.
      */
     AbstractHttpResponse<T> perform(final String path, final String apiKey, final HttpMethod method, final String payload, final MediaType mediaType);
+
+    /**
+     * Perform an HTTP request with the specified path, method, and payload.
+     *
+     * @param path    The path or endpoint of the request.
+     * @param apiKey  The API Key used to authenticate the request.
+     * @param method  The HTTP method (GET, POST, PUT, DELETE, etc.).
+     * @param payload The payload or data to send with the request.
+     * @param mediaType The media type of the request.
+     * @param additionalHeaders A map of header-name → header-value to add.
+     * @return An {@link AbstractHttpResponse} representing the response from the server.
+     */
+    AbstractHttpResponse<T> perform(final String path, final String apiKey, final HttpMethod method, final String payload, final MediaType mediaType, final Map<String,String> additionalHeaders);
 }

--- a/src/main/java/com/resend/services/emails/Emails.java
+++ b/src/main/java/com/resend/services/emails/Emails.java
@@ -7,6 +7,8 @@ import com.resend.core.service.BaseService;
 import com.resend.services.emails.model.*;
 import okhttp3.MediaType;
 
+import java.util.Map;
+
 /**
  *  Represents the Resend Emails module.
  */
@@ -32,6 +34,28 @@ public final class Emails extends BaseService {
 
         String payload = super.resendMapper.writeValue(createEmailOptions);
         AbstractHttpResponse<String> response = super.httpClient.perform("/emails", super.apiKey, HttpMethod.POST, payload, MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new RuntimeException("Failed to send email: " + response.getCode() + " " + response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        return resendMapper.readValue(responseBody, CreateEmailResponse.class);
+    }
+
+    /**
+     * Sends an email based on the provided email request.
+     *
+     * @param createEmailOptions The request containing email details.
+     * @param requestOptions The options with additional headers.
+     * @return The response indicating the status of the email sending.
+     * @throws ResendException If an error occurs while sending the email.
+     */
+    public CreateEmailResponse send(CreateEmailOptions createEmailOptions, Map<String,String> requestOptions) throws ResendException {
+        String payload = super.resendMapper.writeValue(createEmailOptions);
+
+        AbstractHttpResponse<String> response = super.httpClient.perform("/emails", super.apiKey, HttpMethod.POST, payload, MediaType.get("application/json"), requestOptions);
 
         if (!response.isSuccessful()) {
             throw new RuntimeException("Failed to send email: " + response.getCode() + " " + response.getBody());

--- a/src/test/java/com/resend/services/emails/EmailsTest.java
+++ b/src/test/java/com/resend/services/emails/EmailsTest.java
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -54,6 +56,22 @@ public class EmailsTest {
 
         assertNotNull(createEmailResponse);
     }
+
+    @Test
+    public void testSendEmail_WithIdempotencyKey_Success() throws ResendException {
+        CreateEmailResponse expectedResponse = EmailsUtil.createSendEmailResponse();
+        CreateEmailOptions createOptions  = EmailsUtil.createEmailOptions();
+        Map<String, String> requestOptions = EmailsUtil.createRequestOptions();
+
+        when(emails.send(createOptions, requestOptions))
+                .thenReturn(expectedResponse);
+
+        CreateEmailResponse response = emails.send(createOptions, requestOptions);
+
+        assertEquals(expectedResponse, response);
+        verify(emails, times(1)).send(createOptions, requestOptions);
+    }
+
 
     @Test
     public void testCreateBatchEmails_Success() throws ResendException {

--- a/src/test/java/com/resend/services/util/EmailsUtil.java
+++ b/src/test/java/com/resend/services/util/EmailsUtil.java
@@ -6,7 +6,9 @@ import com.resend.services.emails.model.*;
 import com.resend.core.net.AbstractHttpResponse;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class EmailsUtil {
 
@@ -37,6 +39,13 @@ public class EmailsUtil {
                 .tags(Arrays.asList(createTag()))
                 .scheduledAt("2024-08-20T11:52:01.858Z")
                 .build();
+    }
+
+    public static Map<String, String> createRequestOptions() {
+        return Collections.singletonMap(
+                "idempotency_key",
+                "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        );
     }
 
     public static UpdateEmailOptions updateEmailOptions() {


### PR DESCRIPTION
* Optional parameter for adding idempotent key in the send email


example: 

```
import com.resend.*;

public class Main {
    public static void main(String[] args) {
        Resend resend = new Resend("re_123456789");

        CreateEmailOptions params = CreateEmailOptions.builder()
                .from("Acme <onboarding@resend.dev>")
                .to("delivered@resend.dev")
                .subject("hello world")
                .html("<p>it works!</p>")
                .build();

        CreateEmailResponse data = resend.emails().send(params, 
                    Map.of("idempotency_key", "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"));
    }
}
```