### PR TITLE
feat: Add idempotency key to batch emails

### DIFF
--- a/src/main/java/com/resend/core/net/IHttpClient.java
+++ b/src/main/java/com/resend/core/net/IHttpClient.java
@@ -36,4 +36,17 @@ public interface IHttpClient<T> {
      * @return An {@link AbstractHttpResponse} representing the response from the server.
      */
     AbstractHttpResponse<T> perform(final String path, final String apiKey, final HttpMethod method, final String payload, final MediaType mediaType, final Map<String,String> additionalHeaders);
+
+    /**
+     * Perform an HTTP request with the specified path, method, and payload.
+     *
+     * @param path    The path or endpoint of the request.
+     * @param apiKey  The API Key used to authenticate the request.
+     * @param method  The HTTP method (GET, POST, PUT, DELETE, etc.).
+     * @param payload The payload or data to send with the request.
+     * @param mediaType The media type of the request.
+     * @param requestOptions The object containing the request options
+     * @return An {@link AbstractHttpResponse} representing the response from the server.
+     */
+    AbstractHttpResponse<T> perform(final String path, final String apiKey, final HttpMethod method, final String payload, final MediaType mediaType, final RequestOptions requestOptions);
 }

--- a/src/main/java/com/resend/core/net/RequestOptions.java
+++ b/src/main/java/com/resend/core/net/RequestOptions.java
@@ -1,0 +1,65 @@
+package com.resend.core.net;
+
+import com.resend.services.domains.model.CreateDomainOptions;
+
+/**
+ * Represents a request to create a request options.
+ */
+public class RequestOptions {
+    private final String idempotencyKey;
+
+    /**
+     * Constructs a RequestOptions object using the provided builder.
+     *
+     * @param builder The builder to construct the RequestOptions.
+     */
+    public RequestOptions(Builder builder) {
+        this.idempotencyKey = builder.idempotencyKey;
+    }
+
+    /**
+     * Get the idempotency key.
+     *
+     * @return The idempotency key.
+     */
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    /**
+     * Create a new builder instance for constructing RequestOptions objects.
+     *
+     * @return A new builder instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing RequestOptions objects.
+     */
+    public static class Builder {
+        private String idempotencyKey;
+
+        /**
+         * Set the idempotencyKey.
+         *
+         * @param idempotencyKey The idempotency key.
+         * @return The builder instance.
+         */
+        public Builder setIdempotencyKey(String idempotencyKey) {
+            this.idempotencyKey = idempotencyKey;
+            return this;
+        }
+
+
+        /**
+         * Build a new RequestOptions object.
+         *
+         * @return A new RequestOptions object.
+         */
+        public RequestOptions build() {
+            return new RequestOptions(this);
+        }
+    }
+}

--- a/src/main/java/com/resend/core/net/impl/HttpClient.java
+++ b/src/main/java/com/resend/core/net/impl/HttpClient.java
@@ -4,6 +4,7 @@ import com.resend.core.net.AbstractHttpResponse;
 import com.resend.core.net.HttpMethod;
 import com.resend.core.net.IHttpClient;
 
+import com.resend.core.net.RequestOptions;
 import okhttp3.*;
 
 import java.io.IOException;
@@ -80,6 +81,7 @@ public class HttpClient implements IHttpClient<Response> {
      * @param additionalHeaders A map of header-name → header-value to add.
      * @return An {@link AbstractHttpResponse} representing the response from the server.
      */
+    @Deprecated
     public AbstractHttpResponse perform(
             final String path,
             final String apiKey,
@@ -105,6 +107,51 @@ public class HttpClient implements IHttpClient<Response> {
             for (Map.Entry<String,String> h : additionalHeaders.entrySet()) {
                 requestBuilder.addHeader(h.getKey(), h.getValue());
             }
+        }
+
+        Request request = requestBuilder.build();
+
+        try {
+            Response response =  httpClient.newCall(request).execute();
+            return new AbstractHttpResponse(response.code(), response.body().string(), response.isSuccessful());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Performs an HTTP request with the specified path, HTTP method, and payload.
+     *
+     * @param path         The endpoint path.
+     * @param apiKey       Your API key.
+     * @param method       The HTTP method.
+     * @param payload      The body payload (or null).
+     * @param mediaType    The media type for the payload.
+     * @param requestOptions A map of header-name → header-value to add.
+     * @return An {@link AbstractHttpResponse} representing the response from the server.
+     */
+    public AbstractHttpResponse perform(
+            final String path,
+            final String apiKey,
+            final HttpMethod method,
+            final String payload,
+            final MediaType mediaType,
+            final RequestOptions requestOptions) {
+
+        RequestBody requestBody = null;
+        if(payload != null) {
+            requestBody = RequestBody.create(payload, mediaType);
+        }
+
+        Request.Builder requestBuilder = new Request.Builder()
+                .url(BASE_API + path)
+                .addHeader("Accept", "application/json")
+                .addHeader("User-Agent", USER_AGENT)
+                .addHeader("Authorization", "Bearer " + apiKey)
+                .method(method.name(), requestBody);
+
+        if (requestOptions != null && requestOptions.getIdempotencyKey() != null && !requestOptions.getIdempotencyKey().isEmpty()) {
+            requestBuilder.addHeader("Idempotency-Key", requestOptions.getIdempotencyKey());
         }
 
         Request request = requestBuilder.build();

--- a/src/main/java/com/resend/services/batch/Batch.java
+++ b/src/main/java/com/resend/services/batch/Batch.java
@@ -3,6 +3,7 @@ package com.resend.services.batch;
 import com.resend.core.exception.ResendException;
 import com.resend.core.net.AbstractHttpResponse;
 import com.resend.core.net.HttpMethod;
+import com.resend.core.net.RequestOptions;
 import com.resend.core.service.BaseService;
 
 import com.resend.services.batch.model.CreateBatchEmailsResponse;
@@ -10,7 +11,6 @@ import com.resend.services.emails.model.CreateEmailOptions;
 import okhttp3.MediaType;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  *  Represents the Resend Batch module.
@@ -56,7 +56,7 @@ public class Batch extends BaseService {
      * @return The emails ids.
      * @throws ResendException If an error occurs while sending batch emails.
      */
-    public CreateBatchEmailsResponse send(List<CreateEmailOptions> emails, Map<String,String> requestOptions) throws ResendException {
+    public CreateBatchEmailsResponse send(List<CreateEmailOptions> emails, RequestOptions requestOptions) throws ResendException {
 
         String payload = super.resendMapper.writeValue(emails);
         AbstractHttpResponse<String> response = super.httpClient.perform("/emails/batch", super.apiKey, HttpMethod.POST, payload, MediaType.get("application/json"), requestOptions);

--- a/src/main/java/com/resend/services/batch/Batch.java
+++ b/src/main/java/com/resend/services/batch/Batch.java
@@ -10,6 +10,7 @@ import com.resend.services.emails.model.CreateEmailOptions;
 import okhttp3.MediaType;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  *  Represents the Resend Batch module.
@@ -35,6 +36,30 @@ public class Batch extends BaseService {
 
         String payload = super.resendMapper.writeValue(emails);
         AbstractHttpResponse<String> response = super.httpClient.perform("/emails/batch", super.apiKey, HttpMethod.POST, payload, MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new RuntimeException("Failed to send batch emails: " + response.getCode() + " " + response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        CreateBatchEmailsResponse createBatchEmailsResponse = resendMapper.readValue(responseBody, CreateBatchEmailsResponse.class);
+
+        return createBatchEmailsResponse;
+    }
+
+    /**
+     * Sends up to 100 batch emails.
+     *
+     * @param emails batch emails to send.
+     * @param requestOptions The options with additional headers.
+     * @return The emails ids.
+     * @throws ResendException If an error occurs while sending batch emails.
+     */
+    public CreateBatchEmailsResponse send(List<CreateEmailOptions> emails, Map<String,String> requestOptions) throws ResendException {
+
+        String payload = super.resendMapper.writeValue(emails);
+        AbstractHttpResponse<String> response = super.httpClient.perform("/emails/batch", super.apiKey, HttpMethod.POST, payload, MediaType.get("application/json"), requestOptions);
 
         if (!response.isSuccessful()) {
             throw new RuntimeException("Failed to send batch emails: " + response.getCode() + " " + response.getBody());

--- a/src/main/java/com/resend/services/emails/Emails.java
+++ b/src/main/java/com/resend/services/emails/Emails.java
@@ -3,6 +3,7 @@ package com.resend.services.emails;
 import com.resend.core.exception.ResendException;
 import com.resend.core.net.AbstractHttpResponse;
 import com.resend.core.net.HttpMethod;
+import com.resend.core.net.RequestOptions;
 import com.resend.core.service.BaseService;
 import com.resend.services.emails.model.*;
 import okhttp3.MediaType;
@@ -52,6 +53,30 @@ public final class Emails extends BaseService {
      * @return The response indicating the status of the email sending.
      * @throws ResendException If an error occurs while sending the email.
      */
+    public CreateEmailResponse send(CreateEmailOptions createEmailOptions, RequestOptions requestOptions) throws ResendException {
+        String payload = super.resendMapper.writeValue(createEmailOptions);
+
+        AbstractHttpResponse<String> response = super.httpClient.perform("/emails", super.apiKey, HttpMethod.POST, payload, MediaType.get("application/json"), requestOptions);
+
+        if (!response.isSuccessful()) {
+            throw new RuntimeException("Failed to send email: " + response.getCode() + " " + response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        return resendMapper.readValue(responseBody, CreateEmailResponse.class);
+    }
+
+    /**
+     * @deprecated Use {@link #send(CreateEmailOptions, RequestOptions)} instead.
+     * Sends an email based on the provided email request.
+     *
+     * @param createEmailOptions The request containing email details.
+     * @param requestOptions The options with additional headers.
+     * @return The response indicating the status of the email sending.
+     * @throws ResendException If an error occurs while sending the email.
+     */
+    @Deprecated
     public CreateEmailResponse send(CreateEmailOptions createEmailOptions, Map<String,String> requestOptions) throws ResendException {
         String payload = super.resendMapper.writeValue(createEmailOptions);
 

--- a/src/test/java/com/resend/services/emails/EmailsTest.java
+++ b/src/test/java/com/resend/services/emails/EmailsTest.java
@@ -87,6 +87,20 @@ public class EmailsTest {
     }
 
     @Test
+    public void testCreateBatchEmailsWithIdempotencyKey_Success() throws ResendException {
+        List<CreateEmailOptions> batchEmailsRequest = EmailsUtil.createBatchEmailOptions();
+        CreateBatchEmailsResponse expectedRes = EmailsUtil.createBatchEmailsResponse();
+        Map<String, String> requestOptions = EmailsUtil.createRequestOptions();
+
+        when(batch.send(batchEmailsRequest, requestOptions)).thenReturn(expectedRes);
+
+        CreateBatchEmailsResponse sendBatchEmailsResponse = batch.send(batchEmailsRequest, requestOptions);
+
+        assertNotNull(sendBatchEmailsResponse);
+        assertEquals(expectedRes.getData().size(), sendBatchEmailsResponse.getData().size());
+    }
+
+    @Test
     public void testUpdateEmail_Success() throws ResendException {
         UpdateEmailOptions updateEmailOptions = EmailsUtil.updateEmailOptions();
         UpdateEmailResponse expectedRes = EmailsUtil.updateEmailResponse();

--- a/src/test/java/com/resend/services/emails/EmailsTest.java
+++ b/src/test/java/com/resend/services/emails/EmailsTest.java
@@ -1,5 +1,6 @@
 package com.resend.services.emails;
 import com.resend.core.exception.ResendException;
+import com.resend.core.net.RequestOptions;
 import com.resend.services.batch.Batch;
 import com.resend.services.batch.model.CreateBatchEmailsResponse;
 import com.resend.services.emails.model.*;
@@ -61,7 +62,7 @@ public class EmailsTest {
     public void testSendEmail_WithIdempotencyKey_Success() throws ResendException {
         CreateEmailResponse expectedResponse = EmailsUtil.createSendEmailResponse();
         CreateEmailOptions createOptions  = EmailsUtil.createEmailOptions();
-        Map<String, String> requestOptions = EmailsUtil.createRequestOptions();
+        RequestOptions requestOptions = EmailsUtil.createRequestOptions();
 
         when(emails.send(createOptions, requestOptions))
                 .thenReturn(expectedResponse);
@@ -90,7 +91,7 @@ public class EmailsTest {
     public void testCreateBatchEmailsWithIdempotencyKey_Success() throws ResendException {
         List<CreateEmailOptions> batchEmailsRequest = EmailsUtil.createBatchEmailOptions();
         CreateBatchEmailsResponse expectedRes = EmailsUtil.createBatchEmailsResponse();
-        Map<String, String> requestOptions = EmailsUtil.createRequestOptions();
+        RequestOptions requestOptions = EmailsUtil.createRequestOptions();
 
         when(batch.send(batchEmailsRequest, requestOptions)).thenReturn(expectedRes);
 

--- a/src/test/java/com/resend/services/util/EmailsUtil.java
+++ b/src/test/java/com/resend/services/util/EmailsUtil.java
@@ -1,5 +1,6 @@
 package com.resend.services.util;
 
+import com.resend.core.net.RequestOptions;
 import com.resend.services.batch.model.BatchEmail;
 import com.resend.services.batch.model.CreateBatchEmailsResponse;
 import com.resend.services.emails.model.*;
@@ -41,11 +42,9 @@ public class EmailsUtil {
                 .build();
     }
 
-    public static Map<String, String> createRequestOptions() {
-        return Collections.singletonMap(
-                "idempotency_key",
-                "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
-        );
+    public static RequestOptions createRequestOptions() {
+        return RequestOptions.builder()
+                .setIdempotencyKey("welcome-user/123456789").build();
     }
 
     public static UpdateEmailOptions updateEmailOptions() {


### PR DESCRIPTION
- Add idempotency key to batch emails
- Batch emails with idempotency key test

example: 

```
import com.resend.*;

public class Main {
    public static void main(String[] args) {
        Resend resend = new Resend("re_xxxxxxxxx");

        RequestOptions options = RequestOptions.builder()
                .setIdempotencyKey("welcome-user/123456789").build();

        CreateEmailOptions firstEmail = CreateEmailOptions.builder()
            .from("Acme <onboarding@resend.dev>")
            .to("foo@gmail.com")
            .subject("hello world")
            .html("<h1>it works!</h1>")
            .build();

        CreateEmailOptions secondEmail = CreateEmailOptions.builder()
            .from("Acme <onboarding@resend.dev>")
            .to("bar@outlook.com")
            .subject("world hello")
            .html("<p>it works!</p>")
            .build();

        CreateBatchEmailsResponse data = resend.batch().send(
            Arrays.asList(firstEmail, secondEmail),
            options
        );
    }
}
```