### PR TITLE
feat: Inbound emails (beta)

### DIFF
--- a/src/main/java/com/resend/Resend.java
+++ b/src/main/java/com/resend/Resend.java
@@ -7,6 +7,7 @@ import com.resend.services.broadcasts.Broadcasts;
 import com.resend.services.contacts.Contacts;
 import com.resend.services.domains.Domains;
 import com.resend.services.emails.Emails;
+import com.resend.services.receiving.Receiving;
 
 /**
  * The Resend class provides a facade for the Domains and Emails services.
@@ -88,5 +89,14 @@ public class Resend {
      */
     public Broadcasts broadcasts() {
         return new Broadcasts(apiKey);
+    }
+
+    /**
+     * Returns a Receiving object that can be used to interact with the Receiving service for inbound emails.
+     *
+     * @return A Receiving object.
+     */
+    public Receiving receiving() {
+        return new Receiving(apiKey);
     }
 }

--- a/src/main/java/com/resend/services/emails/Emails.java
+++ b/src/main/java/com/resend/services/emails/Emails.java
@@ -192,4 +192,82 @@ public final class Emails extends BaseService {
 
         return resendMapper.readValue(responseBody, ListEmailsResponseSuccess.class);
     }
+
+    /**
+     * Retrieves a single attachment from a sent email.
+     *
+     * @param emailId The unique identifier of the email.
+     * @param attachmentId The unique identifier of the attachment.
+     * @return The attachment details including download URL.
+     * @throws ResendException If an error occurs while retrieving the attachment.
+     */
+    public AttachmentResponse getAttachment(String emailId, String attachmentId) throws ResendException {
+        AbstractHttpResponse<String> response = this.httpClient.perform(
+            "/emails/" + emailId + "/attachments/" + attachmentId,
+            super.apiKey,
+            HttpMethod.GET,
+            null,
+            MediaType.get("application/json")
+        );
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        return resendMapper.readValue(responseBody, AttachmentResponse.class);
+    }
+
+    /**
+     * Retrieves all attachments from a sent email.
+     *
+     * @param emailId The unique identifier of the email.
+     * @return A ListAttachmentsResponse containing all attachments from the email.
+     * @throws ResendException If an error occurs while retrieving the attachments.
+     */
+    public ListAttachmentsResponse listAttachments(String emailId) throws ResendException {
+        AbstractHttpResponse<String> response = this.httpClient.perform(
+            "/emails/" + emailId + "/attachments",
+            super.apiKey,
+            HttpMethod.GET,
+            null,
+            MediaType.get("application/json")
+        );
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        return resendMapper.readValue(responseBody, ListAttachmentsResponse.class);
+    }
+
+    /**
+     * Retrieves a paginated list of attachments from a sent email.
+     *
+     * @param emailId The unique identifier of the email.
+     * @param params The params used to customize the list (pagination).
+     * @return A ListAttachmentsResponse containing the paginated list of attachments.
+     * @throws ResendException If an error occurs while retrieving the attachments.
+     */
+    public ListAttachmentsResponse listAttachments(String emailId, ListParams params) throws ResendException {
+        String pathWithQuery = "/emails/" + emailId + "/attachments" + URLHelper.parse(params);
+        AbstractHttpResponse<String> response = this.httpClient.perform(
+            pathWithQuery,
+            super.apiKey,
+            HttpMethod.GET,
+            null,
+            MediaType.get("application/json")
+        );
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        return resendMapper.readValue(responseBody, ListAttachmentsResponse.class);
+    }
 }

--- a/src/main/java/com/resend/services/emails/model/AttachmentResponse.java
+++ b/src/main/java/com/resend/services/emails/model/AttachmentResponse.java
@@ -1,0 +1,207 @@
+package com.resend.services.emails.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the response when retrieving an attachment from a sent email.
+ */
+public class AttachmentResponse {
+
+    /**
+     * The object type, always "attachment".
+     */
+    @JsonProperty("object")
+    private String object;
+
+    /**
+     * The unique identifier of the attachment.
+     */
+    @JsonProperty("id")
+    private String id;
+
+    /**
+     * The filename of the attachment.
+     */
+    @JsonProperty("filename")
+    private String filename;
+
+    /**
+     * The size of the attachment in bytes.
+     */
+    @JsonProperty("size")
+    private Integer size;
+
+    /**
+     * The MIME content type of the attachment.
+     */
+    @JsonProperty("content_type")
+    private String contentType;
+
+    /**
+     * The content disposition (inline or attachment).
+     */
+    @JsonProperty("content_disposition")
+    private String contentDisposition;
+
+    /**
+     * The content ID for inline attachments.
+     */
+    @JsonProperty("content_id")
+    private String contentId;
+
+    /**
+     * The download URL for the attachment.
+     */
+    @JsonProperty("download_url")
+    private String downloadUrl;
+
+    /**
+     * The expiration timestamp of the download URL.
+     */
+    @JsonProperty("expires_at")
+    private String expiresAt;
+
+    /**
+     * Get the object type.
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Set the object type.
+     * @param object The object type.
+     */
+    public void setObject(String object) {
+        this.object = object;
+    }
+
+    /**
+     * Get the attachment ID.
+     * @return The attachment ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Set the attachment ID.
+     * @param id The attachment ID.
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Get the filename.
+     * @return The filename.
+     */
+    public String getFilename() {
+        return filename;
+    }
+
+    /**
+     * Set the filename.
+     * @param filename The filename.
+     */
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    /**
+     * Get the size in bytes.
+     * @return The size.
+     */
+    public Integer getSize() {
+        return size;
+    }
+
+    /**
+     * Set the size.
+     * @param size The size in bytes.
+     */
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+
+    /**
+     * Get the content type.
+     * @return The content type.
+     */
+    public String getContentType() {
+        return contentType;
+    }
+
+    /**
+     * Set the content type.
+     * @param contentType The content type.
+     */
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    /**
+     * Get the content disposition.
+     * @return The content disposition.
+     */
+    public String getContentDisposition() {
+        return contentDisposition;
+    }
+
+    /**
+     * Set the content disposition.
+     * @param contentDisposition The content disposition.
+     */
+    public void setContentDisposition(String contentDisposition) {
+        this.contentDisposition = contentDisposition;
+    }
+
+    /**
+     * Get the content ID.
+     * @return The content ID.
+     */
+    public String getContentId() {
+        return contentId;
+    }
+
+    /**
+     * Set the content ID.
+     * @param contentId The content ID.
+     */
+    public void setContentId(String contentId) {
+        this.contentId = contentId;
+    }
+
+    /**
+     * Get the download URL.
+     * @return The download URL.
+     */
+    public String getDownloadUrl() {
+        return downloadUrl;
+    }
+
+    /**
+     * Set the download URL.
+     * @param downloadUrl The download URL.
+     */
+    public void setDownloadUrl(String downloadUrl) {
+        this.downloadUrl = downloadUrl;
+    }
+
+    /**
+     * Get the expiration timestamp.
+     * @return The expiration timestamp.
+     */
+    public String getExpiresAt() {
+        return expiresAt;
+    }
+
+    /**
+     * Set the expiration timestamp.
+     * @param expiresAt The expiration timestamp.
+     */
+    public void setExpiresAt(String expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/resend/services/emails/model/ListAttachmentsResponse.java
+++ b/src/main/java/com/resend/services/emails/model/ListAttachmentsResponse.java
@@ -1,0 +1,65 @@
+package com.resend.services.emails.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Represents a successful response for listing attachments.
+ */
+public class ListAttachmentsResponse {
+
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("data")
+    private List<AttachmentResponse> data;
+
+    @JsonProperty("has_more")
+    private Boolean hasMore;
+
+    /**
+     * Default constructor
+     */
+    public ListAttachmentsResponse() {
+    }
+
+    /**
+     * Constructs a successful response for listing attachments.
+     *
+     * @param data The list of attachments.
+     * @param object The object type, always "list".
+     * @param hasMore Whether there are more attachments available for pagination.
+     */
+    public ListAttachmentsResponse(final List<AttachmentResponse> data, final String object, final Boolean hasMore) {
+        this.data = data;
+        this.object = object;
+        this.hasMore = hasMore;
+    }
+
+    /**
+     * Gets the list of attachments.
+     *
+     * @return The list of attachments.
+     */
+    public List<AttachmentResponse> getData() {
+        return data;
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Gets the indicator whether there are more items available for pagination.
+     *
+     * @return Whether there are more items available for pagination.
+     */
+    public Boolean hasMore() {
+        return hasMore;
+    }
+}

--- a/src/main/java/com/resend/services/receiving/Receiving.java
+++ b/src/main/java/com/resend/services/receiving/Receiving.java
@@ -1,0 +1,172 @@
+package com.resend.services.receiving;
+
+import com.resend.core.exception.ResendException;
+import com.resend.core.helper.URLHelper;
+import com.resend.core.net.AbstractHttpResponse;
+import com.resend.core.net.HttpMethod;
+import com.resend.core.net.ListParams;
+import com.resend.core.service.BaseService;
+import com.resend.services.receiving.model.*;
+import okhttp3.MediaType;
+
+/**
+ * Represents the Resend Receiving module for inbound emails.
+ */
+public final class Receiving extends BaseService {
+
+    /**
+     * Constructs an instance of the {@code Receiving} class.
+     *
+     * @param apiKey The apiKey used for authentication.
+     */
+    public Receiving(final String apiKey) {
+        super(apiKey);
+    }
+
+    /**
+     * Retrieves a single received email by its ID.
+     *
+     * @param emailId The unique identifier of the received email.
+     * @return The retrieved received email.
+     * @throws ResendException If an error occurs while retrieving the email.
+     */
+    public ReceivedEmail get(String emailId) throws ResendException {
+        AbstractHttpResponse<String> response = this.httpClient.perform(
+                "/emails/receiving/" + emailId,
+                super.apiKey,
+                HttpMethod.GET,
+                null,
+                MediaType.get("application/json")
+        );
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+        return resendMapper.readValue(responseBody, ReceivedEmail.class);
+    }
+
+    /**
+     * Retrieves a list of all received emails.
+     *
+     * @return A ListReceivedEmailsResponse containing the list of received emails.
+     * @throws ResendException If an error occurs during the retrieval process.
+     */
+    public ListReceivedEmailsResponse list() throws ResendException {
+        AbstractHttpResponse<String> response = this.httpClient.perform(
+                "/emails/receiving",
+                super.apiKey,
+                HttpMethod.GET,
+                null,
+                MediaType.get("application/json")
+        );
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+        return resendMapper.readValue(responseBody, ListReceivedEmailsResponse.class);
+    }
+
+    /**
+     * Retrieves a paginated list of received emails.
+     *
+     * @param params The params used to customize the list.
+     * @return A ListReceivedEmailsResponse containing the paginated list of received emails.
+     * @throws ResendException If an error occurs during the retrieval process.
+     */
+    public ListReceivedEmailsResponse list(ListParams params) throws ResendException {
+        String pathWithQuery = "/emails/receiving" + URLHelper.parse(params);
+        AbstractHttpResponse<String> response = this.httpClient.perform(
+                pathWithQuery,
+                super.apiKey,
+                HttpMethod.GET,
+                null,
+                MediaType.get("application/json")
+        );
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+        return resendMapper.readValue(responseBody, ListReceivedEmailsResponse.class);
+    }
+
+    /**
+     * Retrieves a single attachment from a received email.
+     *
+     * @param emailId The unique identifier of the received email.
+     * @param attachmentId The unique identifier of the attachment.
+     * @return The attachment details including download URL.
+     * @throws ResendException If an error occurs while retrieving the attachment.
+     */
+    public AttachmentDetails getAttachment(String emailId, String attachmentId) throws ResendException {
+        AbstractHttpResponse<String> response = this.httpClient.perform(
+                "/emails/receiving/" + emailId + "/attachments/" + attachmentId,
+                super.apiKey,
+                HttpMethod.GET,
+                null,
+                MediaType.get("application/json")
+        );
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+        return resendMapper.readValue(responseBody, AttachmentDetails.class);
+    }
+
+    /**
+     * Retrieves a list of all attachments for a received email.
+     *
+     * @param emailId The unique identifier of the received email.
+     * @return A ListAttachmentsResponse containing the list of attachments.
+     * @throws ResendException If an error occurs during the retrieval process.
+     */
+    public ListAttachmentsResponse listAttachments(String emailId) throws ResendException {
+        AbstractHttpResponse<String> response = this.httpClient.perform(
+                "/emails/receiving/" + emailId + "/attachments",
+                super.apiKey,
+                HttpMethod.GET,
+                null,
+                MediaType.get("application/json")
+        );
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+        return resendMapper.readValue(responseBody, ListAttachmentsResponse.class);
+    }
+
+    /**
+     * Retrieves a paginated list of attachments for a received email.
+     *
+     * @param emailId The unique identifier of the received email.
+     * @param params The params used to customize the list.
+     * @return A ListAttachmentsResponse containing the paginated list of attachments.
+     * @throws ResendException If an error occurs during the retrieval process.
+     */
+    public ListAttachmentsResponse listAttachments(String emailId, ListParams params) throws ResendException {
+        String pathWithQuery = "/emails/receiving/" + emailId + "/attachments" + URLHelper.parse(params);
+        AbstractHttpResponse<String> response = this.httpClient.perform(
+                pathWithQuery,
+                super.apiKey,
+                HttpMethod.GET,
+                null,
+                MediaType.get("application/json")
+        );
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+        return resendMapper.readValue(responseBody, ListAttachmentsResponse.class);
+    }
+}

--- a/src/main/java/com/resend/services/receiving/model/AttachmentDetails.java
+++ b/src/main/java/com/resend/services/receiving/model/AttachmentDetails.java
@@ -1,0 +1,183 @@
+package com.resend.services.receiving.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents detailed information about an attachment including download URL.
+ */
+public class AttachmentDetails {
+
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("filename")
+    private String filename;
+
+    @JsonProperty("content_type")
+    private String contentType;
+
+    @JsonProperty("content_disposition")
+    private String contentDisposition;
+
+    @JsonProperty("content_id")
+    private String contentId;
+
+    @JsonProperty("download_url")
+    private String downloadUrl;
+
+    @JsonProperty("expires_at")
+    private String expiresAt;
+
+    /**
+     * Default constructor.
+     */
+    public AttachmentDetails() {
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Sets the object type.
+     *
+     * @param object The object type.
+     */
+    public void setObject(String object) {
+        this.object = object;
+    }
+
+    /**
+     * Gets the attachment ID.
+     *
+     * @return The attachment ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the attachment ID.
+     *
+     * @param id The attachment ID.
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the filename.
+     *
+     * @return The filename.
+     */
+    public String getFilename() {
+        return filename;
+    }
+
+    /**
+     * Sets the filename.
+     *
+     * @param filename The filename.
+     */
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    /**
+     * Gets the content type.
+     *
+     * @return The content type.
+     */
+    public String getContentType() {
+        return contentType;
+    }
+
+    /**
+     * Sets the content type.
+     *
+     * @param contentType The content type.
+     */
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    /**
+     * Gets the content disposition.
+     *
+     * @return The content disposition.
+     */
+    public String getContentDisposition() {
+        return contentDisposition;
+    }
+
+    /**
+     * Sets the content disposition.
+     *
+     * @param contentDisposition The content disposition.
+     */
+    public void setContentDisposition(String contentDisposition) {
+        this.contentDisposition = contentDisposition;
+    }
+
+    /**
+     * Gets the content ID.
+     *
+     * @return The content ID.
+     */
+    public String getContentId() {
+        return contentId;
+    }
+
+    /**
+     * Sets the content ID.
+     *
+     * @param contentId The content ID.
+     */
+    public void setContentId(String contentId) {
+        this.contentId = contentId;
+    }
+
+    /**
+     * Gets the download URL.
+     *
+     * @return The download URL.
+     */
+    public String getDownloadUrl() {
+        return downloadUrl;
+    }
+
+    /**
+     * Sets the download URL.
+     *
+     * @param downloadUrl The download URL.
+     */
+    public void setDownloadUrl(String downloadUrl) {
+        this.downloadUrl = downloadUrl;
+    }
+
+    /**
+     * Gets the expiration timestamp.
+     *
+     * @return The expiration timestamp.
+     */
+    public String getExpiresAt() {
+        return expiresAt;
+    }
+
+    /**
+     * Sets the expiration timestamp.
+     *
+     * @param expiresAt The expiration timestamp.
+     */
+    public void setExpiresAt(String expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/resend/services/receiving/model/ListAttachmentsResponse.java
+++ b/src/main/java/com/resend/services/receiving/model/ListAttachmentsResponse.java
@@ -1,0 +1,92 @@
+package com.resend.services.receiving.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Represents a response for listing email attachments.
+ */
+public class ListAttachmentsResponse {
+
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("has_more")
+    private Boolean hasMore;
+
+    @JsonProperty("data")
+    private List<AttachmentDetails> data;
+
+    /**
+     * Default constructor.
+     */
+    public ListAttachmentsResponse() {
+    }
+
+    /**
+     * Constructor with all fields.
+     *
+     * @param object The object type.
+     * @param hasMore Whether there are more items.
+     * @param data The list of attachments.
+     */
+    public ListAttachmentsResponse(String object, Boolean hasMore, List<AttachmentDetails> data) {
+        this.object = object;
+        this.hasMore = hasMore;
+        this.data = data;
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Sets the object type.
+     *
+     * @param object The object type.
+     */
+    public void setObject(String object) {
+        this.object = object;
+    }
+
+    /**
+     * Gets whether there are more items available for pagination.
+     *
+     * @return True if there are more items.
+     */
+    public Boolean hasMore() {
+        return hasMore;
+    }
+
+    /**
+     * Sets whether there are more items.
+     *
+     * @param hasMore Whether there are more items.
+     */
+    public void setHasMore(Boolean hasMore) {
+        this.hasMore = hasMore;
+    }
+
+    /**
+     * Gets the list of attachments.
+     *
+     * @return The list of attachments.
+     */
+    public List<AttachmentDetails> getData() {
+        return data;
+    }
+
+    /**
+     * Sets the list of attachments.
+     *
+     * @param data The list of attachments.
+     */
+    public void setData(List<AttachmentDetails> data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/com/resend/services/receiving/model/ListReceivedEmailsResponse.java
+++ b/src/main/java/com/resend/services/receiving/model/ListReceivedEmailsResponse.java
@@ -1,0 +1,92 @@
+package com.resend.services.receiving.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Represents a response for listing received emails.
+ */
+public class ListReceivedEmailsResponse {
+
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("has_more")
+    private Boolean hasMore;
+
+    @JsonProperty("data")
+    private List<ReceivedEmail> data;
+
+    /**
+     * Default constructor.
+     */
+    public ListReceivedEmailsResponse() {
+    }
+
+    /**
+     * Constructor with all fields.
+     *
+     * @param object The object type.
+     * @param hasMore Whether there are more items.
+     * @param data The list of received emails.
+     */
+    public ListReceivedEmailsResponse(String object, Boolean hasMore, List<ReceivedEmail> data) {
+        this.object = object;
+        this.hasMore = hasMore;
+        this.data = data;
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Sets the object type.
+     *
+     * @param object The object type.
+     */
+    public void setObject(String object) {
+        this.object = object;
+    }
+
+    /**
+     * Gets whether there are more items available for pagination.
+     *
+     * @return True if there are more items.
+     */
+    public Boolean hasMore() {
+        return hasMore;
+    }
+
+    /**
+     * Sets whether there are more items.
+     *
+     * @param hasMore Whether there are more items.
+     */
+    public void setHasMore(Boolean hasMore) {
+        this.hasMore = hasMore;
+    }
+
+    /**
+     * Gets the list of received emails.
+     *
+     * @return The list of received emails.
+     */
+    public List<ReceivedEmail> getData() {
+        return data;
+    }
+
+    /**
+     * Sets the list of received emails.
+     *
+     * @param data The list of received emails.
+     */
+    public void setData(List<ReceivedEmail> data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/com/resend/services/receiving/model/ListReceivedEmailsResponse.java
+++ b/src/main/java/com/resend/services/receiving/model/ListReceivedEmailsResponse.java
@@ -15,7 +15,7 @@ public class ListReceivedEmailsResponse {
     private Boolean hasMore;
 
     @JsonProperty("data")
-    private List<ReceivedEmail> data;
+    private List<ReceivedEmailSummary> data;
 
     /**
      * Default constructor.
@@ -30,7 +30,7 @@ public class ListReceivedEmailsResponse {
      * @param hasMore Whether there are more items.
      * @param data The list of received emails.
      */
-    public ListReceivedEmailsResponse(String object, Boolean hasMore, List<ReceivedEmail> data) {
+    public ListReceivedEmailsResponse(String object, Boolean hasMore, List<ReceivedEmailSummary> data) {
         this.object = object;
         this.hasMore = hasMore;
         this.data = data;
@@ -77,7 +77,7 @@ public class ListReceivedEmailsResponse {
      *
      * @return The list of received emails.
      */
-    public List<ReceivedEmail> getData() {
+    public List<ReceivedEmailSummary> getData() {
         return data;
     }
 
@@ -86,7 +86,7 @@ public class ListReceivedEmailsResponse {
      *
      * @param data The list of received emails.
      */
-    public void setData(List<ReceivedEmail> data) {
+    public void setData(List<ReceivedEmailSummary> data) {
         this.data = data;
     }
 }

--- a/src/main/java/com/resend/services/receiving/model/ReceivedEmail.java
+++ b/src/main/java/com/resend/services/receiving/model/ReceivedEmail.java
@@ -1,0 +1,311 @@
+package com.resend.services.receiving.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a received inbound email.
+ */
+public class ReceivedEmail {
+
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("to")
+    private List<String> to;
+
+    @JsonProperty("from")
+    private String from;
+
+    @JsonProperty("created_at")
+    private String createdAt;
+
+    @JsonProperty("subject")
+    private String subject;
+
+    @JsonProperty("html")
+    private String html;
+
+    @JsonProperty("text")
+    private String text;
+
+    @JsonProperty("headers")
+    private Map<String, String> headers;
+
+    @JsonProperty("bcc")
+    private List<String> bcc;
+
+    @JsonProperty("cc")
+    private List<String> cc;
+
+    @JsonProperty("reply_to")
+    private List<String> replyTo;
+
+    @JsonProperty("message_id")
+    private String messageId;
+
+    @JsonProperty("attachments")
+    private List<ReceivedEmailAttachment> attachments;
+
+    /**
+     * Default constructor.
+     */
+    public ReceivedEmail() {
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Sets the object type.
+     *
+     * @param object The object type.
+     */
+    public void setObject(String object) {
+        this.object = object;
+    }
+
+    /**
+     * Gets the email ID.
+     *
+     * @return The email ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the email ID.
+     *
+     * @param id The email ID.
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the recipient addresses.
+     *
+     * @return The list of recipient addresses.
+     */
+    public List<String> getTo() {
+        return to;
+    }
+
+    /**
+     * Sets the recipient addresses.
+     *
+     * @param to The list of recipient addresses.
+     */
+    public void setTo(List<String> to) {
+        this.to = to;
+    }
+
+    /**
+     * Gets the sender address.
+     *
+     * @return The sender address.
+     */
+    public String getFrom() {
+        return from;
+    }
+
+    /**
+     * Sets the sender address.
+     *
+     * @param from The sender address.
+     */
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    /**
+     * Gets the creation timestamp.
+     *
+     * @return The creation timestamp.
+     */
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * Sets the creation timestamp.
+     *
+     * @param createdAt The creation timestamp.
+     */
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    /**
+     * Gets the email subject.
+     *
+     * @return The email subject.
+     */
+    public String getSubject() {
+        return subject;
+    }
+
+    /**
+     * Sets the email subject.
+     *
+     * @param subject The email subject.
+     */
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    /**
+     * Gets the HTML content.
+     *
+     * @return The HTML content.
+     */
+    public String getHtml() {
+        return html;
+    }
+
+    /**
+     * Sets the HTML content.
+     *
+     * @param html The HTML content.
+     */
+    public void setHtml(String html) {
+        this.html = html;
+    }
+
+    /**
+     * Gets the plain text content.
+     *
+     * @return The plain text content.
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Sets the plain text content.
+     *
+     * @param text The plain text content.
+     */
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    /**
+     * Gets the email headers.
+     *
+     * @return The map of email headers.
+     */
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * Sets the email headers.
+     *
+     * @param headers The map of email headers.
+     */
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+
+    /**
+     * Gets the BCC addresses.
+     *
+     * @return The list of BCC addresses.
+     */
+    public List<String> getBcc() {
+        return bcc;
+    }
+
+    /**
+     * Sets the BCC addresses.
+     *
+     * @param bcc The list of BCC addresses.
+     */
+    public void setBcc(List<String> bcc) {
+        this.bcc = bcc;
+    }
+
+    /**
+     * Gets the CC addresses.
+     *
+     * @return The list of CC addresses.
+     */
+    public List<String> getCc() {
+        return cc;
+    }
+
+    /**
+     * Sets the CC addresses.
+     *
+     * @param cc The list of CC addresses.
+     */
+    public void setCc(List<String> cc) {
+        this.cc = cc;
+    }
+
+    /**
+     * Gets the reply-to addresses.
+     *
+     * @return The list of reply-to addresses.
+     */
+    public List<String> getReplyTo() {
+        return replyTo;
+    }
+
+    /**
+     * Sets the reply-to addresses.
+     *
+     * @param replyTo The list of reply-to addresses.
+     */
+    public void setReplyTo(List<String> replyTo) {
+        this.replyTo = replyTo;
+    }
+
+    /**
+     * Gets the message ID.
+     *
+     * @return The message ID.
+     */
+    public String getMessageId() {
+        return messageId;
+    }
+
+    /**
+     * Sets the message ID.
+     *
+     * @param messageId The message ID.
+     */
+    public void setMessageId(String messageId) {
+        this.messageId = messageId;
+    }
+
+    /**
+     * Gets the list of attachments.
+     *
+     * @return The list of attachments.
+     */
+    public List<ReceivedEmailAttachment> getAttachments() {
+        return attachments;
+    }
+
+    /**
+     * Sets the list of attachments.
+     *
+     * @param attachments The list of attachments.
+     */
+    public void setAttachments(List<ReceivedEmailAttachment> attachments) {
+        this.attachments = attachments;
+    }
+}

--- a/src/main/java/com/resend/services/receiving/model/ReceivedEmailAttachment.java
+++ b/src/main/java/com/resend/services/receiving/model/ReceivedEmailAttachment.java
@@ -23,7 +23,7 @@ public class ReceivedEmailAttachment {
     private String contentId;
 
     @JsonProperty("size")
-    private Long size;
+    private Integer size;
 
     /**
      * Default constructor.
@@ -126,7 +126,7 @@ public class ReceivedEmailAttachment {
      *
      * @return The attachment size.
      */
-    public Long getSize() {
+    public Integer getSize() {
         return size;
     }
 
@@ -135,7 +135,7 @@ public class ReceivedEmailAttachment {
      *
      * @param size The attachment size in bytes.
      */
-    public void setSize(Long size) {
+    public void setSize(Integer size) {
         this.size = size;
     }
 }

--- a/src/main/java/com/resend/services/receiving/model/ReceivedEmailAttachment.java
+++ b/src/main/java/com/resend/services/receiving/model/ReceivedEmailAttachment.java
@@ -1,0 +1,141 @@
+package com.resend.services.receiving.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents an attachment in a received email (summary view).
+ */
+public class ReceivedEmailAttachment {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("filename")
+    private String filename;
+
+    @JsonProperty("content_type")
+    private String contentType;
+
+    @JsonProperty("content_disposition")
+    private String contentDisposition;
+
+    @JsonProperty("content_id")
+    private String contentId;
+
+    @JsonProperty("size")
+    private Long size;
+
+    /**
+     * Default constructor.
+     */
+    public ReceivedEmailAttachment() {
+    }
+
+    /**
+     * Gets the attachment ID.
+     *
+     * @return The attachment ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the attachment ID.
+     *
+     * @param id The attachment ID.
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the filename.
+     *
+     * @return The filename.
+     */
+    public String getFilename() {
+        return filename;
+    }
+
+    /**
+     * Sets the filename.
+     *
+     * @param filename The filename.
+     */
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    /**
+     * Gets the content type.
+     *
+     * @return The content type.
+     */
+    public String getContentType() {
+        return contentType;
+    }
+
+    /**
+     * Sets the content type.
+     *
+     * @param contentType The content type.
+     */
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    /**
+     * Gets the content disposition.
+     *
+     * @return The content disposition.
+     */
+    public String getContentDisposition() {
+        return contentDisposition;
+    }
+
+    /**
+     * Sets the content disposition.
+     *
+     * @param contentDisposition The content disposition.
+     */
+    public void setContentDisposition(String contentDisposition) {
+        this.contentDisposition = contentDisposition;
+    }
+
+    /**
+     * Gets the content ID.
+     *
+     * @return The content ID.
+     */
+    public String getContentId() {
+        return contentId;
+    }
+
+    /**
+     * Sets the content ID.
+     *
+     * @param contentId The content ID.
+     */
+    public void setContentId(String contentId) {
+        this.contentId = contentId;
+    }
+
+    /**
+     * Gets the attachment size in bytes.
+     *
+     * @return The attachment size.
+     */
+    public Long getSize() {
+        return size;
+    }
+
+    /**
+     * Sets the attachment size.
+     *
+     * @param size The attachment size in bytes.
+     */
+    public void setSize(Long size) {
+        this.size = size;
+    }
+}

--- a/src/main/java/com/resend/services/receiving/model/ReceivedEmailSummary.java
+++ b/src/main/java/com/resend/services/receiving/model/ReceivedEmailSummary.java
@@ -1,0 +1,249 @@
+package com.resend.services.receiving.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Represents a summary of a received inbound email (used in list responses).
+ * This class omits the html, text, and headers fields which are only available
+ * when fetching a specific email by ID.
+ */
+public class ReceivedEmailSummary {
+
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("to")
+    private List<String> to;
+
+    @JsonProperty("from")
+    private String from;
+
+    @JsonProperty("created_at")
+    private String createdAt;
+
+    @JsonProperty("subject")
+    private String subject;
+
+    @JsonProperty("bcc")
+    private List<String> bcc;
+
+    @JsonProperty("cc")
+    private List<String> cc;
+
+    @JsonProperty("reply_to")
+    private List<String> replyTo;
+
+    @JsonProperty("message_id")
+    private String messageId;
+
+    @JsonProperty("attachments")
+    private List<ReceivedEmailAttachment> attachments;
+
+    /**
+     * Default constructor.
+     */
+    public ReceivedEmailSummary() {
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Sets the object type.
+     *
+     * @param object The object type.
+     */
+    public void setObject(String object) {
+        this.object = object;
+    }
+
+    /**
+     * Gets the email ID.
+     *
+     * @return The email ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the email ID.
+     *
+     * @param id The email ID.
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the recipient addresses.
+     *
+     * @return The list of recipient addresses.
+     */
+    public List<String> getTo() {
+        return to;
+    }
+
+    /**
+     * Sets the recipient addresses.
+     *
+     * @param to The list of recipient addresses.
+     */
+    public void setTo(List<String> to) {
+        this.to = to;
+    }
+
+    /**
+     * Gets the sender address.
+     *
+     * @return The sender address.
+     */
+    public String getFrom() {
+        return from;
+    }
+
+    /**
+     * Sets the sender address.
+     *
+     * @param from The sender address.
+     */
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    /**
+     * Gets the creation timestamp.
+     *
+     * @return The creation timestamp.
+     */
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * Sets the creation timestamp.
+     *
+     * @param createdAt The creation timestamp.
+     */
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    /**
+     * Gets the email subject.
+     *
+     * @return The email subject.
+     */
+    public String getSubject() {
+        return subject;
+    }
+
+    /**
+     * Sets the email subject.
+     *
+     * @param subject The email subject.
+     */
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    /**
+     * Gets the BCC addresses.
+     *
+     * @return The list of BCC addresses.
+     */
+    public List<String> getBcc() {
+        return bcc;
+    }
+
+    /**
+     * Sets the BCC addresses.
+     *
+     * @param bcc The list of BCC addresses.
+     */
+    public void setBcc(List<String> bcc) {
+        this.bcc = bcc;
+    }
+
+    /**
+     * Gets the CC addresses.
+     *
+     * @return The list of CC addresses.
+     */
+    public List<String> getCc() {
+        return cc;
+    }
+
+    /**
+     * Sets the CC addresses.
+     *
+     * @param cc The list of CC addresses.
+     */
+    public void setCc(List<String> cc) {
+        this.cc = cc;
+    }
+
+    /**
+     * Gets the reply-to addresses.
+     *
+     * @return The list of reply-to addresses.
+     */
+    public List<String> getReplyTo() {
+        return replyTo;
+    }
+
+    /**
+     * Sets the reply-to addresses.
+     *
+     * @param replyTo The list of reply-to addresses.
+     */
+    public void setReplyTo(List<String> replyTo) {
+        this.replyTo = replyTo;
+    }
+
+    /**
+     * Gets the message ID.
+     *
+     * @return The message ID.
+     */
+    public String getMessageId() {
+        return messageId;
+    }
+
+    /**
+     * Sets the message ID.
+     *
+     * @param messageId The message ID.
+     */
+    public void setMessageId(String messageId) {
+        this.messageId = messageId;
+    }
+
+    /**
+     * Gets the list of attachments.
+     *
+     * @return The list of attachments.
+     */
+    public List<ReceivedEmailAttachment> getAttachments() {
+        return attachments;
+    }
+
+    /**
+     * Sets the list of attachments.
+     *
+     * @param attachments The list of attachments.
+     */
+    public void setAttachments(List<ReceivedEmailAttachment> attachments) {
+        this.attachments = attachments;
+    }
+}

--- a/src/test/java/com/resend/services/emails/EmailsTest.java
+++ b/src/test/java/com/resend/services/emails/EmailsTest.java
@@ -166,4 +166,56 @@ public class EmailsTest {
         assertNotNull(response);
         assertEquals(params.getLimit(), response.getData().size());
     }
+
+    @Test
+    public void testGetAttachment_Success() throws ResendException {
+        String emailId = "4ef9a417-02e9-4d39-ad75-9611e0fcc33c";
+        String attachmentId = "2a0c9ce0-3112-4728-976e-47ddcd16a318";
+        AttachmentResponse expectedResponse = EmailsUtil.createAttachmentResponse();
+
+        when(emails.getAttachment(emailId, attachmentId)).thenReturn(expectedResponse);
+
+        AttachmentResponse response = emails.getAttachment(emailId, attachmentId);
+
+        assertNotNull(response);
+        assertEquals(expectedResponse.getId(), response.getId());
+        assertEquals(expectedResponse.getFilename(), response.getFilename());
+        assertEquals(expectedResponse.getSize(), response.getSize());
+        assertEquals(expectedResponse.getContentType(), response.getContentType());
+        assertEquals(expectedResponse.getDownloadUrl(), response.getDownloadUrl());
+        verify(emails, times(1)).getAttachment(emailId, attachmentId);
+    }
+
+    @Test
+    public void testListAttachments_Success() throws ResendException {
+        String emailId = "4ef9a417-02e9-4d39-ad75-9611e0fcc33c";
+        ListAttachmentsResponse expectedResponse = EmailsUtil.createListAttachmentsResponse();
+
+        when(emails.listAttachments(emailId)).thenReturn(expectedResponse);
+
+        ListAttachmentsResponse response = emails.listAttachments(emailId);
+
+        assertNotNull(response);
+        assertEquals(expectedResponse.getData().size(), response.getData().size());
+        assertEquals(expectedResponse.getObject(), response.getObject());
+        verify(emails, times(1)).listAttachments(emailId);
+    }
+
+    @Test
+    public void testListAttachmentsWithPagination_Success() throws ResendException {
+        String emailId = "4ef9a417-02e9-4d39-ad75-9611e0fcc33c";
+        ListParams params = ListParams.builder()
+                .limit(10)
+                .build();
+        ListAttachmentsResponse expectedResponse = EmailsUtil.createListAttachmentsResponse();
+
+        when(emails.listAttachments(emailId, params)).thenReturn(expectedResponse);
+
+        ListAttachmentsResponse response = emails.listAttachments(emailId, params);
+
+        assertNotNull(response);
+        assertEquals(expectedResponse.getData().size(), response.getData().size());
+        assertEquals(expectedResponse.hasMore(), response.hasMore());
+        verify(emails, times(1)).listAttachments(emailId, params);
+    }
 }

--- a/src/test/java/com/resend/services/receiving/ReceivingTest.java
+++ b/src/test/java/com/resend/services/receiving/ReceivingTest.java
@@ -1,0 +1,123 @@
+package com.resend.services.receiving;
+
+import com.resend.core.exception.ResendException;
+import com.resend.core.net.ListParams;
+import com.resend.services.receiving.model.*;
+import com.resend.services.util.ReceivingUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class for Receiving service.
+ */
+public class ReceivingTest {
+
+    @Mock
+    private Receiving receiving;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        receiving = mock(Receiving.class);
+    }
+
+    @Test
+    public void testGetReceivedEmail_Success() throws ResendException {
+        ReceivedEmail expectedEmail = ReceivingUtil.createReceivedEmail();
+
+        when(receiving.get(expectedEmail.getId())).thenReturn(expectedEmail);
+
+        ReceivedEmail result = receiving.get(expectedEmail.getId());
+
+        assertNotNull(result);
+        assertEquals(expectedEmail.getId(), result.getId());
+        assertEquals(expectedEmail.getSubject(), result.getSubject());
+        assertEquals(expectedEmail.getFrom(), result.getFrom());
+        assertEquals(expectedEmail.getMessageId(), result.getMessageId());
+        verify(receiving, times(1)).get(expectedEmail.getId());
+    }
+
+    @Test
+    public void testListReceivedEmails_Success() throws ResendException {
+        ListReceivedEmailsResponse expectedResponse = ReceivingUtil.createListReceivedEmailsResponse();
+
+        when(receiving.list()).thenReturn(expectedResponse);
+
+        ListReceivedEmailsResponse result = receiving.list();
+
+        assertNotNull(result);
+        assertEquals(expectedResponse.getData().size(), result.getData().size());
+        assertEquals(expectedResponse.hasMore(), result.hasMore());
+        assertEquals("list", result.getObject());
+        verify(receiving, times(1)).list();
+    }
+
+    @Test
+    public void testListReceivedEmailsWithPagination_Success() throws ResendException {
+        ListParams params = ListParams.builder().limit(10).build();
+        ListReceivedEmailsResponse expectedResponse = ReceivingUtil.createListReceivedEmailsResponse();
+
+        when(receiving.list(params)).thenReturn(expectedResponse);
+
+        ListReceivedEmailsResponse result = receiving.list(params);
+
+        assertNotNull(result);
+        assertEquals(expectedResponse.getData().size(), result.getData().size());
+        verify(receiving, times(1)).list(params);
+    }
+
+    @Test
+    public void testGetAttachment_Success() throws ResendException {
+        String emailId = "4ef9a417-02e9-4d39-ad75-9611e0fcc33c";
+        String attachmentId = "2a0c9ce0-3112-4728-976e-47ddcd16a318";
+        AttachmentDetails expectedDetails = ReceivingUtil.createAttachmentDetails();
+
+        when(receiving.getAttachment(emailId, attachmentId)).thenReturn(expectedDetails);
+
+        AttachmentDetails result = receiving.getAttachment(emailId, attachmentId);
+
+        assertNotNull(result);
+        assertEquals(expectedDetails.getId(), result.getId());
+        assertEquals(expectedDetails.getFilename(), result.getFilename());
+        assertEquals(expectedDetails.getDownloadUrl(), result.getDownloadUrl());
+        assertEquals("attachment", result.getObject());
+        verify(receiving, times(1)).getAttachment(emailId, attachmentId);
+    }
+
+    @Test
+    public void testListAttachments_Success() throws ResendException {
+        String emailId = "4ef9a417-02e9-4d39-ad75-9611e0fcc33c";
+        ListAttachmentsResponse expectedResponse = ReceivingUtil.createListAttachmentsResponse();
+
+        when(receiving.listAttachments(emailId)).thenReturn(expectedResponse);
+
+        ListAttachmentsResponse result = receiving.listAttachments(emailId);
+
+        assertNotNull(result);
+        assertEquals(expectedResponse.getData().size(), result.getData().size());
+        assertEquals(expectedResponse.hasMore(), result.hasMore());
+        assertEquals("list", result.getObject());
+        verify(receiving, times(1)).listAttachments(emailId);
+    }
+
+    @Test
+    public void testListAttachmentsWithPagination_Success() throws ResendException {
+        String emailId = "4ef9a417-02e9-4d39-ad75-9611e0fcc33c";
+        ListParams params = ListParams.builder().limit(5).build();
+        ListAttachmentsResponse expectedResponse = ReceivingUtil.createListAttachmentsResponse();
+
+        when(receiving.listAttachments(emailId, params)).thenReturn(expectedResponse);
+
+        ListAttachmentsResponse result = receiving.listAttachments(emailId, params);
+
+        assertNotNull(result);
+        assertEquals(expectedResponse.getData().size(), result.getData().size());
+        verify(receiving, times(1)).listAttachments(emailId, params);
+    }
+}

--- a/src/test/java/com/resend/services/util/EmailsUtil.java
+++ b/src/test/java/com/resend/services/util/EmailsUtil.java
@@ -159,4 +159,53 @@ public class EmailsUtil {
         return new AbstractHttpResponse(200, "test", true);
 
     }
+
+    public static AttachmentResponse createAttachmentResponse() {
+        AttachmentResponse response = new AttachmentResponse();
+        response.setObject("attachment");
+        response.setId("2a0c9ce0-3112-4728-976e-47ddcd16a318");
+        response.setFilename("avatar.png");
+        response.setSize(4096);
+        response.setContentType("image/png");
+        response.setContentDisposition("inline");
+        response.setContentId("img001");
+        response.setDownloadUrl("https://outbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123");
+        response.setExpiresAt("2025-10-17T14:29:41.521Z");
+        return response;
+    }
+
+    public static List<AttachmentResponse> createAttachmentResponseList() {
+        List<AttachmentResponse> attachments = new ArrayList<>();
+
+        AttachmentResponse attachment1 = new AttachmentResponse();
+        attachment1.setObject("attachment");
+        attachment1.setId("2a0c9ce0-3112-4728-976e-47ddcd16a318");
+        attachment1.setFilename("avatar.png");
+        attachment1.setSize(4096);
+        attachment1.setContentType("image/png");
+        attachment1.setContentDisposition("inline");
+        attachment1.setContentId("img001");
+        attachment1.setDownloadUrl("https://outbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123");
+        attachment1.setExpiresAt("2025-10-17T14:29:41.521Z");
+
+        AttachmentResponse attachment2 = new AttachmentResponse();
+        attachment2.setObject("attachment");
+        attachment2.setId("3b0d9ce0-4223-5839-087f-58eede27b429");
+        attachment2.setFilename("invoice.pdf");
+        attachment2.setSize(8192);
+        attachment2.setContentType("application/pdf");
+        attachment2.setContentDisposition("attachment");
+        attachment2.setContentId("doc001");
+        attachment2.setDownloadUrl("https://outbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/3b0d9ce0-4223-5839-087f-58eede27b429?some-params=example&signature=sig-456");
+        attachment2.setExpiresAt("2025-10-17T14:29:41.521Z");
+
+        attachments.add(attachment1);
+        attachments.add(attachment2);
+
+        return attachments;
+    }
+
+    public static ListAttachmentsResponse createListAttachmentsResponse() {
+        return new ListAttachmentsResponse(createAttachmentResponseList(), "list", false);
+    }
 }

--- a/src/test/java/com/resend/services/util/ReceivingUtil.java
+++ b/src/test/java/com/resend/services/util/ReceivingUtil.java
@@ -1,0 +1,133 @@
+package com.resend.services.util;
+
+import com.resend.services.receiving.model.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility class for creating test data for Receiving service tests.
+ */
+public class ReceivingUtil {
+
+    /**
+     * Creates a sample ReceivedEmail for testing.
+     *
+     * @return A ReceivedEmail instance.
+     */
+    public static ReceivedEmail createReceivedEmail() {
+        ReceivedEmail email = new ReceivedEmail();
+        email.setObject("email");
+        email.setId("4ef9a417-02e9-4d39-ad75-9611e0fcc33c");
+        email.setTo(Arrays.asList("delivered@resend.dev"));
+        email.setFrom("Acme <onboarding@resend.dev>");
+        email.setCreatedAt("2023-04-03T22:13:42.674981+00:00");
+        email.setSubject("Hello World");
+        email.setHtml("Congrats on sending your <strong>first email</strong>!");
+        email.setText(null);
+
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("return-path", "lucas.costa@resend.com");
+        headers.put("mime-version", "1.0");
+        email.setHeaders(headers);
+
+        email.setBcc(new ArrayList<String>());
+        email.setCc(new ArrayList<String>());
+        email.setReplyTo(new ArrayList<String>());
+        email.setMessageId("<example+123>");
+
+        List<ReceivedEmailAttachment> attachments = new ArrayList<ReceivedEmailAttachment>();
+        ReceivedEmailAttachment attachment = new ReceivedEmailAttachment();
+        attachment.setId("2a0c9ce0-3112-4728-976e-47ddcd16a318");
+        attachment.setFilename("avatar.png");
+        attachment.setContentType("image/png");
+        attachment.setContentDisposition("inline");
+        attachment.setContentId("img001");
+        attachments.add(attachment);
+
+        email.setAttachments(attachments);
+        return email;
+    }
+
+    /**
+     * Creates a list of sample ReceivedEmails for testing.
+     *
+     * @return A list of ReceivedEmail instances.
+     */
+    public static List<ReceivedEmail> createReceivedEmailList() {
+        List<ReceivedEmail> emails = new ArrayList<ReceivedEmail>();
+
+        ReceivedEmail email1 = new ReceivedEmail();
+        email1.setId("a39999a6-88e3-48b1-888b-beaabcde1b33");
+        email1.setTo(Arrays.asList("recipient@example.com"));
+        email1.setFrom("sender@example.com");
+        email1.setCreatedAt("2025-10-09 14:37:40.951732+00");
+        email1.setSubject("Hello World");
+        email1.setBcc(new ArrayList<String>());
+        email1.setCc(new ArrayList<String>());
+        email1.setReplyTo(new ArrayList<String>());
+        email1.setMessageId("<111-222-333@email.provider.example.com>");
+
+        ReceivedEmailAttachment attachment1 = new ReceivedEmailAttachment();
+        attachment1.setFilename("example.txt");
+        attachment1.setContentType("text/plain");
+        attachment1.setContentId(null);
+        attachment1.setContentDisposition("attachment");
+        attachment1.setId("47e999c7-c89c-4999-bf32-aaaaa1c3ff21");
+        attachment1.setSize(13L);
+        email1.setAttachments(Arrays.asList(attachment1));
+
+        emails.add(email1);
+        return emails;
+    }
+
+    /**
+     * Creates a sample ListReceivedEmailsResponse for testing.
+     *
+     * @return A ListReceivedEmailsResponse instance.
+     */
+    public static ListReceivedEmailsResponse createListReceivedEmailsResponse() {
+        return new ListReceivedEmailsResponse("list", true, createReceivedEmailList());
+    }
+
+    /**
+     * Creates a sample AttachmentDetails for testing.
+     *
+     * @return An AttachmentDetails instance.
+     */
+    public static AttachmentDetails createAttachmentDetails() {
+        AttachmentDetails details = new AttachmentDetails();
+        details.setObject("attachment");
+        details.setId("2a0c9ce0-3112-4728-976e-47ddcd16a318");
+        details.setFilename("avatar.png");
+        details.setContentType("image/png");
+        details.setContentDisposition("inline");
+        details.setContentId("img001");
+        details.setDownloadUrl("https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123");
+        details.setExpiresAt("2025-10-17T14:29:41.521Z");
+        return details;
+    }
+
+    /**
+     * Creates a list of sample AttachmentDetails for testing.
+     *
+     * @return A list of AttachmentDetails instances.
+     */
+    public static List<AttachmentDetails> createAttachmentDetailsList() {
+        List<AttachmentDetails> attachments = new ArrayList<AttachmentDetails>();
+        attachments.add(createAttachmentDetails());
+        return attachments;
+    }
+
+    /**
+     * Creates a sample ListAttachmentsResponse for testing.
+     *
+     * @return A ListAttachmentsResponse instance.
+     */
+    public static ListAttachmentsResponse createListAttachmentsResponse() {
+        return new ListAttachmentsResponse("list", false, createAttachmentDetailsList());
+    }
+}

--- a/src/test/java/com/resend/services/util/ReceivingUtil.java
+++ b/src/test/java/com/resend/services/util/ReceivingUtil.java
@@ -57,10 +57,10 @@ public class ReceivingUtil {
      *
      * @return A list of ReceivedEmail instances.
      */
-    public static List<ReceivedEmail> createReceivedEmailList() {
-        List<ReceivedEmail> emails = new ArrayList<ReceivedEmail>();
+    public static List<ReceivedEmailSummary> createReceivedEmailList() {
+        List<ReceivedEmailSummary> emails = new ArrayList<>();
 
-        ReceivedEmail email1 = new ReceivedEmail();
+        ReceivedEmailSummary email1 = new ReceivedEmailSummary();
         email1.setId("a39999a6-88e3-48b1-888b-beaabcde1b33");
         email1.setTo(Arrays.asList("recipient@example.com"));
         email1.setFrom("sender@example.com");
@@ -77,7 +77,7 @@ public class ReceivingUtil {
         attachment1.setContentId(null);
         attachment1.setContentDisposition("attachment");
         attachment1.setId("47e999c7-c89c-4999-bf32-aaaaa1c3ff21");
-        attachment1.setSize(13L);
+        attachment1.setSize(13);
         email1.setAttachments(Arrays.asList(attachment1));
 
         emails.add(email1);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds inbound email receiving (beta) to the Java SDK so you can list and fetch received emails and their attachments. Exposes a new Receiving service via Resend.receiving().

- **New Features**
  - Receiving service: get(emailId), list(), and list(ListParams) for inbound emails.
  - Attachment APIs: listAttachments(emailId), listAttachments(emailId, ListParams), getAttachment(emailId, attachmentId) returning download_url.
  - New models: ReceivedEmail, ReceivedEmailAttachment, AttachmentDetails, ListReceivedEmailsResponse, ListAttachmentsResponse.
  - Resend facade updated with receiving() accessor.

<!-- End of auto-generated description by cubic. -->

