### PR TITLE
feat: Add update and list methods for contact topics

### DIFF
--- a/src/main/java/com/resend/services/contacts/Contacts.java
+++ b/src/main/java/com/resend/services/contacts/Contacts.java
@@ -165,4 +165,84 @@ public class Contacts extends BaseService {
 
         return resendMapper.readValue(responseBody, UpdateContactResponseSuccess.class);
     }
+
+    /**
+     * Retrieves a list of topic subscriptions for a contact.
+     *
+     * @param contactIdOrEmail The contact ID or email address.
+     * @return A ListContactTopicsResponse containing the list of topic subscriptions.
+     * @throws ResendException If an error occurs during the topic list retrieval process.
+     */
+    public ListContactTopicsResponse getTopics(String contactIdOrEmail) throws ResendException {
+        if (contactIdOrEmail == null || contactIdOrEmail.isEmpty()) {
+            throw new IllegalArgumentException("Contact ID or email must be provided");
+        }
+
+        AbstractHttpResponse<String> response = this.httpClient.perform("/contacts/" + contactIdOrEmail + "/topics", super.apiKey, HttpMethod.GET, null, MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        return resendMapper.readValue(responseBody, ListContactTopicsResponse.class);
+    }
+
+    /**
+     * Retrieves a paginated list of topic subscriptions for a contact.
+     *
+     * @param contactIdOrEmail The contact ID or email address.
+     * @param params           The params used to customize the list.
+     * @return A ListContactTopicsResponse containing the paginated list of topic subscriptions.
+     * @throws ResendException If an error occurs during the topic list retrieval process.
+     */
+    public ListContactTopicsResponse getTopics(String contactIdOrEmail, ListParams params) throws ResendException {
+        if (contactIdOrEmail == null || contactIdOrEmail.isEmpty()) {
+            throw new IllegalArgumentException("Contact ID or email must be provided");
+        }
+
+        String pathWithQuery = "/contacts/" + contactIdOrEmail + "/topics" + URLHelper.parse(params);
+        AbstractHttpResponse<String> response = this.httpClient.perform(pathWithQuery, super.apiKey, HttpMethod.GET, null, MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        return resendMapper.readValue(responseBody, ListContactTopicsResponse.class);
+    }
+
+    /**
+     * Updates topic subscriptions for a contact.
+     *
+     * @param options The options containing the contact identifier and topic updates.
+     * @return The UpdateContactTopicsResponse with the contact ID.
+     * @throws ResendException If an error occurs during the topic update process.
+     */
+    public UpdateContactTopicsResponse updateTopics(UpdateContactTopicsOptions options) throws ResendException {
+        if ((options.getId() == null && options.getEmail() == null) ||
+                (options.getId() != null && options.getEmail() != null)) {
+            throw new IllegalArgumentException("Either 'id' or 'email' must be provided, but not both.");
+        }
+
+        if (options.getTopics() == null || options.getTopics().isEmpty()) {
+            throw new IllegalArgumentException("Topics list must not be empty");
+        }
+
+        String contactIdOrEmail = options.getId() != null ? options.getId() : options.getEmail();
+
+        // Serialize just the topics array (not the whole options object)
+        String payload = super.resendMapper.writeValue(options.getTopics());
+        AbstractHttpResponse<String> response = httpClient.perform("/contacts/" + contactIdOrEmail + "/topics", super.apiKey, HttpMethod.PATCH, payload, MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        return resendMapper.readValue(responseBody, UpdateContactTopicsResponse.class);
+    }
 }

--- a/src/main/java/com/resend/services/contacts/model/ContactTopic.java
+++ b/src/main/java/com/resend/services/contacts/model/ContactTopic.java
@@ -1,0 +1,78 @@
+package com.resend.services.contacts.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a contact topic subscription.
+ */
+public class ContactTopic {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("subscription")
+    private String subscription;
+
+    /**
+     * Default constructor
+     */
+    public ContactTopic() {
+    }
+
+    /**
+     * Creates an instance of ContactTopic with the specified attributes.
+     *
+     * @param id            The ID of the topic.
+     * @param name          The name of the topic.
+     * @param description   The description of the topic.
+     * @param subscription  The subscription status (opt_in or opt_out).
+     */
+    public ContactTopic(final String id, final String name, final String description, final String subscription) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.subscription = subscription;
+    }
+
+    /**
+     * Gets the ID of the topic.
+     *
+     * @return The ID of the topic.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the name of the topic.
+     *
+     * @return The name of the topic.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the description of the topic.
+     *
+     * @return The description of the topic.
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Gets the subscription status of the topic.
+     *
+     * @return The subscription status (opt_in or opt_out).
+     */
+    public String getSubscription() {
+        return subscription;
+    }
+}

--- a/src/main/java/com/resend/services/contacts/model/ContactTopicOptions.java
+++ b/src/main/java/com/resend/services/contacts/model/ContactTopicOptions.java
@@ -20,7 +20,7 @@ public class ContactTopicOptions {
     }
 
     /**
-     * Creates an instance of TopicSubscriptionOptions.
+     * Creates an instance of ContactTopicOptions.
      *
      * @param id            The topic ID.
      * @param subscription  The subscription action (opt_in or opt_out).

--- a/src/main/java/com/resend/services/contacts/model/ContactTopicOptions.java
+++ b/src/main/java/com/resend/services/contacts/model/ContactTopicOptions.java
@@ -105,7 +105,7 @@ public class ContactTopicOptions {
         }
 
         /**
-         * Builds the TopicSubscriptionOptions instance.
+         * Builds the ContactTopicOptions instance.
          *
          * @return A new TopicSubscriptionOptions instance.
          */

--- a/src/main/java/com/resend/services/contacts/model/ContactTopicOptions.java
+++ b/src/main/java/com/resend/services/contacts/model/ContactTopicOptions.java
@@ -1,0 +1,116 @@
+package com.resend.services.contacts.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents options for a topic subscription update.
+ */
+public class ContactTopicOptions {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("subscription")
+    private String subscription;
+
+    /**
+     * Default constructor
+     */
+    public ContactTopicOptions() {
+    }
+
+    /**
+     * Creates an instance of TopicSubscriptionOptions.
+     *
+     * @param id            The topic ID.
+     * @param subscription  The subscription action (opt_in or opt_out).
+     */
+    public ContactTopicOptions(final String id, final String subscription) {
+        this.id = id;
+        this.subscription = subscription;
+    }
+
+    /**
+     * Gets the topic ID.
+     *
+     * @return The topic ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the topic ID.
+     *
+     * @param id The topic ID.
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the subscription action.
+     *
+     * @return The subscription action (opt_in or opt_out).
+     */
+    public String getSubscription() {
+        return subscription;
+    }
+
+    /**
+     * Sets the subscription action.
+     *
+     * @param subscription The subscription action (opt_in or opt_out).
+     */
+    public void setSubscription(String subscription) {
+        this.subscription = subscription;
+    }
+
+    /**
+     * Creates a builder for TopicSubscriptionOptions.
+     *
+     * @return A new builder instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for TopicSubscriptionOptions.
+     */
+    public static class Builder {
+        private String id;
+        private String subscription;
+
+        /**
+         * Sets the topic ID.
+         *
+         * @param id The topic ID.
+         * @return This builder instance.
+         */
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * Sets the subscription action.
+         *
+         * @param subscription The subscription action (opt_in or opt_out).
+         * @return This builder instance.
+         */
+        public Builder subscription(String subscription) {
+            this.subscription = subscription;
+            return this;
+        }
+
+        /**
+         * Builds the TopicSubscriptionOptions instance.
+         *
+         * @return A new TopicSubscriptionOptions instance.
+         */
+        public ContactTopicOptions build() {
+            return new ContactTopicOptions(id, subscription);
+        }
+    }
+}

--- a/src/main/java/com/resend/services/contacts/model/ContactTopicOptions.java
+++ b/src/main/java/com/resend/services/contacts/model/ContactTopicOptions.java
@@ -67,7 +67,7 @@ public class ContactTopicOptions {
     }
 
     /**
-     * Creates a builder for TopicSubscriptionOptions.
+     * Creates a builder for ContactTopicOptions.
      *
      * @return A new builder instance.
      */

--- a/src/main/java/com/resend/services/contacts/model/ContactTopicOptions.java
+++ b/src/main/java/com/resend/services/contacts/model/ContactTopicOptions.java
@@ -76,7 +76,7 @@ public class ContactTopicOptions {
     }
 
     /**
-     * Builder for TopicSubscriptionOptions.
+     * Builder for ContactTopicOptions.
      */
     public static class Builder {
         private String id;

--- a/src/main/java/com/resend/services/contacts/model/ListContactTopicsResponse.java
+++ b/src/main/java/com/resend/services/contacts/model/ListContactTopicsResponse.java
@@ -1,0 +1,66 @@
+package com.resend.services.contacts.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents a successful response for listing contact topics.
+ */
+public class ListContactTopicsResponse {
+
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("data")
+    private List<ContactTopic> data;
+
+    @JsonProperty("has_more")
+    private Boolean hasMore;
+
+    /**
+     * Default constructor
+     */
+    public ListContactTopicsResponse() {
+    }
+
+    /**
+     * Constructs a successful response for listing contact topics.
+     *
+     * @param object   The object type.
+     * @param data     The list of contact topics.
+     * @param hasMore  Whether there are more items available for pagination.
+     */
+    public ListContactTopicsResponse(final String object, final List<ContactTopic> data, final Boolean hasMore) {
+        this.object = object;
+        this.data = data;
+        this.hasMore = hasMore;
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Gets the list of contact topics.
+     *
+     * @return The list of contact topics.
+     */
+    public List<ContactTopic> getData() {
+        return data;
+    }
+
+    /**
+     * Gets the indicator whether there are more items available for pagination.
+     *
+     * @return Whether there are more items available for pagination.
+     */
+    public Boolean hasMore() {
+        return hasMore;
+    }
+}

--- a/src/main/java/com/resend/services/contacts/model/UpdateContactTopicsOptions.java
+++ b/src/main/java/com/resend/services/contacts/model/UpdateContactTopicsOptions.java
@@ -3,6 +3,8 @@ package com.resend.services.contacts.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -104,6 +106,21 @@ public class UpdateContactTopicsOptions {
          */
         public Builder topics(List<ContactTopicOptions> topics) {
             this.topics = topics;
+            return this;
+        }
+
+        /**
+         * Sets the list of topic subscription updates using varargs.
+         *
+         * @param topics The list of topic subscription updates.
+         * @return The builder instance.
+         */
+        public Builder topics(ContactTopicOptions... topics) {
+            if (this.topics == null) {
+                this.topics = new ArrayList<>();
+            }
+
+            this.topics.addAll(Arrays.asList(topics));
             return this;
         }
 

--- a/src/main/java/com/resend/services/contacts/model/UpdateContactTopicsOptions.java
+++ b/src/main/java/com/resend/services/contacts/model/UpdateContactTopicsOptions.java
@@ -1,0 +1,119 @@
+package com.resend.services.contacts.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents options for updating contact topic subscriptions.
+ */
+public class UpdateContactTopicsOptions {
+
+    @JsonIgnore
+    private final String id;
+
+    @JsonIgnore
+    private final String email;
+
+    @JsonProperty("topics")
+    private final List<ContactTopicOptions> topics;
+
+    /**
+     * Constructs an UpdateContactTopicsOptions object using the provided builder.
+     *
+     * @param builder The builder to construct the options.
+     */
+    public UpdateContactTopicsOptions(Builder builder) {
+        this.id = builder.id;
+        this.email = builder.email;
+        this.topics = builder.topics;
+    }
+
+    /**
+     * Gets the contact ID.
+     *
+     * @return The contact ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the contact email.
+     *
+     * @return The contact email.
+     */
+    public String getEmail() {
+        return email;
+    }
+
+    /**
+     * Gets the list of topic subscription updates.
+     *
+     * @return The list of topic subscription updates.
+     */
+    public List<ContactTopicOptions> getTopics() {
+        return topics;
+    }
+
+    /**
+     * Creates a new builder instance for constructing UpdateContactTopicsOptions objects.
+     *
+     * @return A new builder instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing UpdateContactTopicsOptions objects.
+     */
+    public static class Builder {
+        private String id;
+        private String email;
+        private List<ContactTopicOptions> topics;
+
+        /**
+         * Sets the contact ID.
+         *
+         * @param id The contact ID.
+         * @return The builder instance.
+         */
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * Sets the contact email.
+         *
+         * @param email The contact email.
+         * @return The builder instance.
+         */
+        public Builder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        /**
+         * Sets the list of topic subscription updates.
+         *
+         * @param topics The list of topic subscription updates.
+         * @return The builder instance.
+         */
+        public Builder topics(List<ContactTopicOptions> topics) {
+            this.topics = topics;
+            return this;
+        }
+
+        /**
+         * Builds a new UpdateContactTopicsOptions object.
+         *
+         * @return A new UpdateContactTopicsOptions object.
+         */
+        public UpdateContactTopicsOptions build() {
+            return new UpdateContactTopicsOptions(this);
+        }
+    }
+}

--- a/src/main/java/com/resend/services/contacts/model/UpdateContactTopicsResponse.java
+++ b/src/main/java/com/resend/services/contacts/model/UpdateContactTopicsResponse.java
@@ -1,0 +1,36 @@
+package com.resend.services.contacts.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a successful response for updating contact topics.
+ */
+public class UpdateContactTopicsResponse {
+
+    @JsonProperty("id")
+    private String id;
+
+    /**
+     * Default constructor
+     */
+    public UpdateContactTopicsResponse() {
+    }
+
+    /**
+     * Constructs an UpdateContactTopicsResponse with the specified contact ID.
+     *
+     * @param id The contact ID.
+     */
+    public UpdateContactTopicsResponse(final String id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the contact ID.
+     *
+     * @return The contact ID.
+     */
+    public String getId() {
+        return id;
+    }
+}

--- a/src/test/java/com/resend/services/contacts/ContactsTest.java
+++ b/src/test/java/com/resend/services/contacts/ContactsTest.java
@@ -137,4 +137,70 @@ public class ContactsTest {
         assertEquals(expected, res);
         verify(contacts, times(1)).get(params);
     }
+
+    @Test
+    public void testGetTopicsById_Success() throws ResendException {
+        String contactId = "e169aa45-1ecf-4183-9955-b1499d5701d3";
+        ListContactTopicsResponse expectedResponse = ContactsUtil.createContactTopicsListResponse();
+
+        when(contacts.getTopics(contactId))
+                .thenReturn(expectedResponse);
+
+        ListContactTopicsResponse res = contacts.getTopics(contactId);
+
+        assertNotNull(res);
+        assertEquals(expectedResponse.getData().size(), res.getData().size());
+        assertEquals(expectedResponse.getObject(), res.getObject());
+        verify(contacts, times(1)).getTopics(contactId);
+    }
+
+    @Test
+    public void testGetTopicsByEmail_Success() throws ResendException {
+        String contactEmail = "steve.wozniak@gmail.com";
+        ListContactTopicsResponse expectedResponse = ContactsUtil.createContactTopicsListResponse();
+
+        when(contacts.getTopics(contactEmail))
+                .thenReturn(expectedResponse);
+
+        ListContactTopicsResponse res = contacts.getTopics(contactEmail);
+
+        assertNotNull(res);
+        assertEquals(expectedResponse.getData().size(), res.getData().size());
+        assertEquals(expectedResponse.getObject(), res.getObject());
+        verify(contacts, times(1)).getTopics(contactEmail);
+    }
+
+    @Test
+    public void testGetTopicsWithPagination_Success() throws ResendException {
+        String contactId = "e169aa45-1ecf-4183-9955-b1499d5701d3";
+        ListParams params = ListParams.builder()
+                .limit(10)
+                .build();
+        ListContactTopicsResponse expectedResponse = ContactsUtil.createContactTopicsListResponse();
+
+        when(contacts.getTopics(contactId, params))
+                .thenReturn(expectedResponse);
+
+        ListContactTopicsResponse res = contacts.getTopics(contactId, params);
+
+        assertNotNull(res);
+        assertEquals(expectedResponse.getData().size(), res.getData().size());
+        assertEquals(expectedResponse.getObject(), res.getObject());
+        verify(contacts, times(1)).getTopics(contactId, params);
+    }
+
+    @Test
+    public void testUpdateTopics_Success() throws ResendException {
+        UpdateContactTopicsOptions options = ContactsUtil.createUpdateTopicsOptions();
+        UpdateContactTopicsResponse expectedResponse = ContactsUtil.updateContactTopicsResponse();
+
+        when(contacts.updateTopics(options))
+                .thenReturn(expectedResponse);
+
+        UpdateContactTopicsResponse res = contacts.updateTopics(options);
+
+        assertNotNull(res);
+        assertEquals(expectedResponse.getId(), res.getId());
+        verify(contacts, times(1)).updateTopics(options);
+    }
 }

--- a/src/test/java/com/resend/services/util/ContactsUtil.java
+++ b/src/test/java/com/resend/services/util/ContactsUtil.java
@@ -60,4 +60,47 @@ public class ContactsUtil {
                 false
         );
     }
+
+    public static ListContactTopicsResponse createContactTopicsListResponse() {
+        List<ContactTopic> topics = new ArrayList<>();
+
+        ContactTopic t1 = new ContactTopic(
+                "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+                "Product Updates",
+                "New features, and latest announcements.",
+                "opt_in"
+        );
+        ContactTopic t2 = new ContactTopic(
+                "07d84122-7224-4881-9c31-1c048e204602",
+                "Weekly Newsletter",
+                "Weekly digest of content.",
+                "opt_out"
+        );
+
+        topics.add(t1);
+        topics.add(t2);
+
+        return new ListContactTopicsResponse("list", topics, false);
+    }
+
+    public static UpdateContactTopicsOptions createUpdateTopicsOptions() {
+        List<ContactTopicOptions> updates = new ArrayList<>();
+        updates.add(ContactTopicOptions.builder()
+                .id("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+                .subscription("opt_out")
+                .build());
+        updates.add(ContactTopicOptions.builder()
+                .id("07d84122-7224-4881-9c31-1c048e204602")
+                .subscription("opt_in")
+                .build());
+
+        return UpdateContactTopicsOptions.builder()
+                .id("e169aa45-1ecf-4183-9955-b1499d5701d3")
+                .topics(updates)
+                .build();
+    }
+
+    public static UpdateContactTopicsResponse updateContactTopicsResponse() {
+        return new UpdateContactTopicsResponse("e169aa45-1ecf-4183-9955-b1499d5701d3");
+    }
 }


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds list and update methods for contact topics in the Contacts service so clients can fetch and modify topic subscriptions by contact ID or email.

- **New Features**
  - List topics: Contacts.getTopics(idOrEmail) and Contacts.getTopics(idOrEmail, ListParams) return ListContactTopicsResponse with pagination support.
  - Update topics: Contacts.updateTopics(UpdateContactTopicsOptions) PATCHes /contacts/{idOrEmail}/topics, requires either id or email (not both) and a non-empty topics array; body includes only the topics array; returns UpdateContactTopicsResponse.
  - Models and tests: Added ContactTopic, ContactTopicOptions, ListContactTopicsResponse, UpdateContactTopicsOptions, UpdateContactTopicsResponse, with unit tests for listing and updating.

<sup>Written for commit bb85076. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



