### PR TITLE
chore: Bump to v4.9.0-alpha.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.resend
-VERSION_NAME=4.8.0
+VERSION_NAME=4.9.0-alpha.1
 
 POM_URL=https://github.com/resendlabs/resend-java
 POM_SCM_URL=https://github.com/resendlabs/resend-java.git

--- a/src/main/java/com/resend/core/net/impl/HttpClient.java
+++ b/src/main/java/com/resend/core/net/impl/HttpClient.java
@@ -20,7 +20,7 @@ public class HttpClient implements IHttpClient<Response> {
     public static final String BASE_API = "https://api.resend.com";
 
     /** The version of the API */
-    private static final String VERSION_NAME = "4.8.0";
+    private static final String VERSION_NAME = "4.9.0-alpha.1";
 
     /** The User-Agent header value for HTTP requests. */
     public static final String USER_AGENT = "resend-java/" + VERSION_NAME;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump SDK to v4.9.0-alpha.1 and update HttpClient VERSION_NAME so the User-Agent header reports the new version in requests.

<!-- End of auto-generated description by cubic. -->

