### PR TITLE
feat: add global contacts methods

### DIFF
--- a/src/test/java/com/resend/services/contacts/ContactsTest.java
+++ b/src/test/java/com/resend/services/contacts/ContactsTest.java
@@ -203,4 +203,132 @@ public class ContactsTest {
         assertEquals(expectedResponse.getId(), res.getId());
         verify(contacts, times(1)).updateTopics(options);
     }
+
+    // Global contacts tests (without segment ID)
+
+    @Test
+    public void testCreateGlobalContact_Success() throws ResendException {
+        CreateContactResponseSuccess expectedContact = ContactsUtil.createContactResponseSuccess();
+        CreateContactOptions param = CreateContactOptions.builder()
+                .email("user@example.com")
+                .firstName("John")
+                .lastName("Doe")
+                .build();
+
+        when(contacts.create(param))
+                .thenReturn(expectedContact);
+
+        CreateContactResponseSuccess createdContact = contacts.create(param);
+
+        assertEquals(createdContact, expectedContact);
+        verify(contacts, times(1)).create(param);
+    }
+
+    @Test
+    public void testListGlobalContacts_Success() throws ResendException {
+        ListContactsResponseSuccess expectedResponse = ContactsUtil.createContactsListResponse();
+
+        when(contacts.list())
+                .thenReturn(expectedResponse);
+
+        ListContactsResponseSuccess res = contacts.list();
+
+        assertNotNull(res);
+        assertEquals(expectedResponse.getData().size(), res.getData().size());
+        assertEquals(expectedResponse.getObject(), res.getObject());
+    }
+
+    @Test
+    public void testListGlobalContactsWithPagination_Success() throws ResendException {
+        ListParams params = ListParams.builder()
+                .limit(3).build();
+
+        ListContactsResponseSuccess expectedResponse = ContactsUtil.createContactsListResponse();
+
+        when(contacts.list(params))
+                .thenReturn(expectedResponse);
+
+        ListContactsResponseSuccess res = contacts.list(params);
+
+        assertNotNull(res);
+        assertEquals(params.getLimit(), res.getData().size());
+        assertEquals(expectedResponse.getObject(), res.getObject());
+    }
+
+    @Test
+    public void testGetGlobalContactById_Success() throws ResendException {
+        String contactId = "e169aa45-1ecf-4183-9955-b1499d5701d3";
+        GetContactResponseSuccess expected = ContactsUtil.getContactResponseSuccess();
+
+        when(contacts.get(contactId)).thenReturn(expected);
+
+        GetContactResponseSuccess res = contacts.get(contactId);
+
+        assertNotNull(res);
+        assertEquals(expected, res);
+        verify(contacts, times(1)).get(contactId);
+    }
+
+    @Test
+    public void testGetGlobalContactByEmail_Success() throws ResendException {
+        String contactEmail = "user@example.com";
+        GetContactResponseSuccess expected = ContactsUtil.getContactResponseSuccess();
+
+        when(contacts.get(contactEmail)).thenReturn(expected);
+
+        GetContactResponseSuccess res = contacts.get(contactEmail);
+
+        assertNotNull(res);
+        assertEquals(expected, res);
+        verify(contacts, times(1)).get(contactEmail);
+    }
+
+    @Test
+    public void testRemoveGlobalContactById_Success() throws ResendException {
+        String contactId = "e169aa45-1ecf-4183-9955-b1499d5701d3";
+        RemoveContactResponseSuccess removed = ContactsUtil.removeContactResponseSuccess();
+
+        when(contacts.remove(contactId))
+                .thenReturn(removed);
+
+        RemoveContactResponseSuccess res = contacts.remove(contactId);
+
+        assertEquals(removed, res);
+        verify(contacts, times(1)).remove(contactId);
+    }
+
+    @Test
+    public void testUpdateGlobalContact_Success() throws ResendException {
+        UpdateContactOptions params = UpdateContactOptions.builder()
+                .id("e169aa45-1ecf-4183-9955-b1499d5701d3")
+                .firstName("Jane")
+                .lastName("Smith")
+                .build();
+        UpdateContactResponseSuccess expectedResponse = ContactsUtil.updateContactResponseSuccess();
+
+        when(contacts.update(params))
+                .thenReturn(expectedResponse);
+
+        UpdateContactResponseSuccess res = contacts.update(params);
+
+        assertNotNull(res);
+        assertEquals(expectedResponse.getId(), res.getId());
+        assertEquals(expectedResponse.getObject(), res.getObject());
+    }
+
+    @Test
+    public void testGetContactWithoutSegmentId_Success() throws ResendException {
+        GetContactOptions params = GetContactOptions.builder()
+                .id("e169aa45-1ecf-4183-9955-b1499d5701d3")
+                .build();
+        GetContactResponseSuccess expected = ContactsUtil.getContactResponseSuccess();
+
+        when(contacts.get(params)).thenReturn(expected);
+
+        GetContactResponseSuccess res = contacts.get(params);
+
+        assertNotNull(res);
+        assertEquals(expected, res);
+        verify(contacts, times(1)).get(params);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for global contacts not tied to a segment/audience. When no segmentId/audienceId is provided, the SDK now uses /contacts to create, list, get, update, and delete contacts.

- **New Features**
  - create() auto-routes to /contacts when no segment/audience is set.
  - Added list() and list(ListParams) for global contacts.
  - Added get(String contactIdOrEmail) for global contacts.
  - Added remove(String contactId) for global contacts (ID only, not email).
  - Updated get/update/remove to pick the correct endpoint based on segment/audience presence.
  - Added tests covering all global contact flows.

<sup>Written for commit 6564f53. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

