### PR TITLE
feat: create and send broadcasts on the same request

### DIFF
--- a/src/main/java/com/resend/services/broadcasts/model/CreateBroadcastOptions.java
+++ b/src/main/java/com/resend/services/broadcasts/model/CreateBroadcastOptions.java
@@ -1,9 +1,18 @@
 package com.resend.services.broadcasts.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
- * Class representing options to create a broadcast.
+ * Represents options for creating a broadcast.
+ * Extends {@link BroadcastOptions} with additional fields for immediate sending and scheduling.
  */
 public class CreateBroadcastOptions extends BroadcastOptions {
+
+    @JsonProperty("send")
+    private final Boolean send;
+
+    @JsonProperty("scheduled_at")
+    private final String scheduledAt;
 
     /**
      * Constructs a CreateBroadcastOptions object using the provided builder.
@@ -12,10 +21,30 @@ public class CreateBroadcastOptions extends BroadcastOptions {
      */
     public CreateBroadcastOptions(Builder builder) {
         super(builder);
+        this.send = builder.send;
+        this.scheduledAt = builder.scheduledAt;
     }
 
     /**
-     * Create a new builder instance for constructing CreateBroadcastOptions objects.
+     * Gets the send flag indicating whether the broadcast should be sent immediately.
+     *
+     * @return true if the broadcast should be sent immediately, false or null for draft.
+     */
+    public Boolean getSend() {
+        return send;
+    }
+
+    /**
+     * Gets the scheduled time for sending the broadcast.
+     *
+     * @return The scheduled time in ISO 8601 format, or null if not scheduled.
+     */
+    public String getScheduledAt() {
+        return scheduledAt;
+    }
+
+    /**
+     * Creates a new builder instance for constructing CreateBroadcastOptions objects.
      *
      * @return A new builder instance.
      */
@@ -24,14 +53,40 @@ public class CreateBroadcastOptions extends BroadcastOptions {
     }
 
     /**
-     * Builder class for constructing BroadcastOptions objects.
+     * Builder class for constructing CreateBroadcastOptions objects.
      */
     public static class Builder extends BroadcastOptions.Builder<CreateBroadcastOptions, Builder> {
 
+        private Boolean send;
+        private String scheduledAt;
+
         /**
-         * Build a new BroadcastOptions object.
+         * Sets the send flag to immediately send the broadcast upon creation.
          *
-         * @return A new BroadcastOptions object.
+         * @param send true to send immediately, false or null to create as draft.
+         * @return The builder instance for chaining.
+         */
+        public Builder send(Boolean send) {
+            this.send = send;
+            return self();
+        }
+
+        /**
+         * Sets the scheduled time for sending the broadcast.
+         * Only valid when send is set to true.
+         *
+         * @param scheduledAt The scheduled time in ISO 8601 format (e.g., "2024-12-25T10:00:00.000Z").
+         * @return The builder instance for chaining.
+         */
+        public Builder scheduledAt(String scheduledAt) {
+            this.scheduledAt = scheduledAt;
+            return self();
+        }
+
+        /**
+         * Builds a new CreateBroadcastOptions object.
+         *
+         * @return A new CreateBroadcastOptions object.
          */
         @Override
         public CreateBroadcastOptions build() {
@@ -39,7 +94,7 @@ public class CreateBroadcastOptions extends BroadcastOptions {
         }
 
         /**
-         * Return the builder instance.
+         * Returns the builder instance.
          *
          * @return The builder instance.
          */

--- a/src/main/java/com/resend/services/contacts/model/CreateContactOptions.java
+++ b/src/main/java/com/resend/services/contacts/model/CreateContactOptions.java
@@ -7,12 +7,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Represents a request to create a global contact.
  *
  * <p><strong>Note:</strong> This class is for creating global contacts only.
- * To add a contact to a segment, use the workflow:
+ * To add a contact to a segment, use the workflow:</p>
  * <ol>
  *   <li>Create global contact: {@code resend.contacts().create(options)}</li>
  *   <li>Add to segment: {@code resend.contacts().segments().add(options)}</li>
  * </ol>
- * </p>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CreateContactOptions {

--- a/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
+++ b/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
@@ -123,5 +123,34 @@ public class BroadcastsTest {
         verify(broadcasts, times(1)).list(params);
     }
 
+    @Test
+    public void testCreateAndSendBroadcast_Success() throws ResendException {
+        CreateBroadcastResponseSuccess expectedResponse = BroadcastsUtil.createBroadcastResponse();
+        CreateBroadcastOptions createOptions = BroadcastsUtil.createAndSendBroadcastRequest();
+
+        when(broadcasts.create(createOptions)).thenReturn(expectedResponse);
+
+        CreateBroadcastResponseSuccess response = broadcasts.create(createOptions);
+
+        assertEquals(expectedResponse, response);
+        assertTrue(createOptions.getSend());
+        verify(broadcasts, times(1)).create(createOptions);
+    }
+
+    @Test
+    public void testCreateAndScheduleBroadcast_Success() throws ResendException {
+        CreateBroadcastResponseSuccess expectedResponse = BroadcastsUtil.createBroadcastResponse();
+        CreateBroadcastOptions createOptions = BroadcastsUtil.createAndScheduleBroadcastRequest();
+
+        when(broadcasts.create(createOptions)).thenReturn(expectedResponse);
+
+        CreateBroadcastResponseSuccess response = broadcasts.create(createOptions);
+
+        assertEquals(expectedResponse, response);
+        assertTrue(createOptions.getSend());
+        assertNotNull(createOptions.getScheduledAt());
+        verify(broadcasts, times(1)).create(createOptions);
+    }
+
 }
 

--- a/src/test/java/com/resend/services/util/BroadcastsUtil.java
+++ b/src/test/java/com/resend/services/util/BroadcastsUtil.java
@@ -85,5 +85,30 @@ public class BroadcastsUtil {
                 .scheduledAt("2024-12-18T15:00:00.000Z")
                 .build();
     }
+
+    public static CreateBroadcastOptions createAndSendBroadcastRequest() {
+        return CreateBroadcastOptions.builder()
+                .audienceId("78261eea-8f8b-4381-83c6-79fa7120f1cf")
+                .from("example@resend.dev")
+                .subject("Sample Subject")
+                .html("<p>This is a test email.</p>")
+                .text("This is a test email.")
+                .name("Sample Broadcast")
+                .send(true)
+                .build();
+    }
+
+    public static CreateBroadcastOptions createAndScheduleBroadcastRequest() {
+        return CreateBroadcastOptions.builder()
+                .audienceId("78261eea-8f8b-4381-83c6-79fa7120f1cf")
+                .from("example@resend.dev")
+                .subject("Sample Subject")
+                .html("<p>This is a test email.</p>")
+                .text("This is a test email.")
+                .name("Sample Broadcast")
+                .send(true)
+                .scheduledAt("2024-12-18T15:00:00.000Z")
+                .build();
+    }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable creating and sending broadcasts in a single request, with optional scheduling. Adds send and scheduledAt fields to CreateBroadcastOptions and updates tests/utilities to support them.

- **New Features**
  - Add send flag to CreateBroadcastOptions to send on create.
  - Add scheduledAt (ISO 8601) for scheduled send when send=true.
  - Builder and serialization: send(Boolean), scheduledAt(String) with JSON properties; tests cover create+send and create+schedule.

<sup>Written for commit 3cb1643dfcd18d2468c029445a8152aa7368eb7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

