### PR TITLE
fix: upgrade okhttp to 4.12.0 to resolve CVE-2023-3635

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
 
-    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation("org.json:json:20250517")
 }
 


### PR DESCRIPTION
## Summary

  Upgrades `com.squareup.okhttp3:okhttp` from `4.11.0` to `4.12.0`.

  OkHttp 4.11.0 depends transitively on `okio-jvm:3.2.0`, which is
  affected by [CVE-2023-3635](https://nvd.nist.gov/vuln/detail/CVE-2023-3635)
  (CVSS 5.9). OkHttp 4.12.0 depends on `okio:3.6.0`, which contains the fix.

  Fixes #83

  ## Details

  - **CVE:** [CVE-2023-3635](https://nvd.nist.gov/vuln/detail/CVE-2023-3635)
  - **Vulnerable component:** `com.squareup.okio:okio-jvm` < 3.4.0
  - **Fixed in:** `okio` 3.4.0+ (okhttp 4.12.0 uses okio 3.6.0)
  - **Severity:** Medium (CVSS 5.9)

  ## Test plan

  - [x] All existing unit tests pass (`./gradlew clean test`)
  - [x] No breaking changes — okhttp 4.12.0 is a minor bump, fully
        backwards-compatible with 4.11.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded OkHttp to 4.12.0 to resolve CVE-2023-3635 by pulling in Okio 3.6.0. Minor update with no breaking changes.

<sup>Written for commit 3237450ea2715744b3c37a97a28ea83483870b3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

