### PR TITLE
docs(domains): mention TrackingCAA in Record javadoc

### DIFF
--- a/src/main/java/com/resend/services/domains/model/Record.java
+++ b/src/main/java/com/resend/services/domains/model/Record.java
@@ -4,6 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Represents a DNS record associated with a domain.
+ *
+ * <p>The {@code record} field identifies which kind of DNS record this is
+ * (e.g. {@code SPF}, {@code DKIM}, {@code Receiving}, {@code Tracking},
+ * {@code TrackingCAA}). The {@code type} field is the underlying DNS
+ * record type (e.g. {@code MX}, {@code TXT}, {@code CNAME}, {@code CAA}).</p>
  */
 public class Record {
 


### PR DESCRIPTION
## Summary

The Domains API now returns an extra DNS record on `POST /domains` and `GET /domains/:id` when a tracking subdomain is configured **and** the customer's root domain has CAA records that would prevent AWS from issuing a certificate for the tracking subdomain:

```json
{
  "record": "TrackingCAA",
  "name": "",
  "type": "CAA",
  "ttl": "Auto",
  "value": "0 issue \"amazon.com\"",
  "status": "verified"
}
```

The `Record` model already uses generic `String` fields for `record` and `type`, so no source change is required — the new record deserializes today. This PR updates the `Record` javadoc to enumerate the known record kinds (`SPF`, `DKIM`, `Receiving`, `Tracking`, `TrackingCAA`) so consumers know what values to expect.

The existing `DomainsTest` suite mocks the `Domains` service rather than exercising real Jackson deserialization, so there's no record-parsing fixture to extend here.

## Test plan

- [ ] CI runs `mvn test` (no local Maven available)

Tracking: [Linear ENG-4845](https://linear.app/resend/issue/ENG-4845/java)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Domains `Record` model javadoc to list known record kinds and clarify the DNS `type`. Adds `TrackingCAA` to match the API response when a tracking subdomain is configured and root-domain CAA would block AWS certificate issuance (Linear ENG-4845).

<sup>Written for commit aec337b8b2243816a0e4ea7620ea9cb278763dda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

