### PR TITLE
chore(ci): harden security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
 name: Java
+
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]
@@ -8,6 +12,7 @@ on:
 jobs:
   gradle-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Set up Java

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,14 @@ on:
   release:
     types: [created]
 
+concurrency:
+  group: publish-maven-central-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -20,7 +25,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3
 
       - name: Run tests
         run: ./gradlew test


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens GitHub Actions for `resend-java` by adding least-privilege permissions, release concurrency, job timeouts, and pinning `gradle/actions/setup-gradle` to a commit. Addresses DEV-657 (1 high, 2 med, 2 low).

- **Refactors**
  - `ci.yml`: add `permissions: contents: read`; set `timeout-minutes: 30` for `gradle-tests`.
  - `release.yml`: add `concurrency` grouped by tag; set `timeout-minutes: 60`; pin `gradle/actions/setup-gradle` to a commit.

<sup>Written for commit f5fa30cb9e0304d1da43e4f7b1ae0a1ebc645838. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

