### PR TITLE
feat: add received_for to ReceivedEmail

### DIFF
--- a/src/main/java/com/resend/services/receiving/model/ReceivedEmail.java
+++ b/src/main/java/com/resend/services/receiving/model/ReceivedEmail.java
@@ -45,6 +45,9 @@ public class ReceivedEmail {
     @JsonProperty("reply_to")
     private List<String> replyTo;
 
+    @JsonProperty("received_for")
+    private List<String> receivedFor;
+
     @JsonProperty("message_id")
     private String messageId;
 
@@ -271,6 +274,24 @@ public class ReceivedEmail {
      */
     public void setReplyTo(List<String> replyTo) {
         this.replyTo = replyTo;
+    }
+
+    /**
+     * Gets the addresses the email was received for (forwarding recipients).
+     *
+     * @return The list of addresses the email was received for.
+     */
+    public List<String> getReceivedFor() {
+        return receivedFor;
+    }
+
+    /**
+     * Sets the addresses the email was received for (forwarding recipients).
+     *
+     * @param receivedFor The list of addresses the email was received for.
+     */
+    public void setReceivedFor(List<String> receivedFor) {
+        this.receivedFor = receivedFor;
     }
 
     /**

--- a/src/test/java/com/resend/services/receiving/ReceivingTest.java
+++ b/src/test/java/com/resend/services/receiving/ReceivingTest.java
@@ -40,6 +40,7 @@ public class ReceivingTest {
         assertEquals(expectedEmail.getSubject(), result.getSubject());
         assertEquals(expectedEmail.getFrom(), result.getFrom());
         assertEquals(expectedEmail.getMessageId(), result.getMessageId());
+        assertEquals(expectedEmail.getReceivedFor(), result.getReceivedFor());
         verify(receiving, times(1)).get(expectedEmail.getId());
     }
 

--- a/src/test/java/com/resend/services/util/ReceivingUtil.java
+++ b/src/test/java/com/resend/services/util/ReceivingUtil.java
@@ -37,6 +37,7 @@ public class ReceivingUtil {
         email.setBcc(new ArrayList<String>());
         email.setCc(new ArrayList<String>());
         email.setReplyTo(new ArrayList<String>());
+        email.setReceivedFor(Arrays.asList("forwarded@example.com"));
         email.setMessageId("<example+123>");
 
         List<ReceivedEmailAttachment> attachments = new ArrayList<ReceivedEmailAttachment>();


### PR DESCRIPTION
Adds the received_for field to the received email response type, matching the API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the received_for field to the ReceivedEmail model to expose forwarding recipients and align the SDK with the API. Updates tests and the test helper to cover the new field.

<sup>Written for commit 0057c54e7a136e21a85f1ae928bb1c129ef2c1aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-java/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

