### PR TITLE
test(batch): verify tags serialize in batch payloads

### DIFF
--- a/src/main/java/com/resend/services/batch/Batch.java
+++ b/src/main/java/com/resend/services/batch/Batch.java
@@ -34,7 +34,6 @@ public class Batch extends BaseService {
      * Sends up to 100 batch emails.
      *
      * <p>Each email supports standard send options plus {@code tags}.
-     * {@code attachments} and {@code scheduled_at} are not supported for batch emails.
      *
      * @param emails batch emails to send.
      * @return The emails ids.
@@ -58,7 +57,6 @@ public class Batch extends BaseService {
      * Sends up to 100 batch emails.
      *
      * <p>Each email supports standard send options plus {@code tags}.
-     * {@code attachments} and {@code scheduled_at} are not supported for batch emails.
      *
      * @param emails batch emails to send.
      * @param requestOptions The options with additional headers.

--- a/src/main/java/com/resend/services/batch/Batch.java
+++ b/src/main/java/com/resend/services/batch/Batch.java
@@ -33,8 +33,8 @@ public class Batch extends BaseService {
     /**
      * Sends up to 100 batch emails.
      *
-     * <p>Each email supports the same options as single sends, including
-     * {@code scheduled_at}, {@code tags}, and {@code attachments}.
+     * <p>Each email supports standard send options plus {@code tags}.
+     * {@code attachments} and {@code scheduled_at} are not supported for batch emails.
      *
      * @param emails batch emails to send.
      * @return The emails ids.
@@ -57,8 +57,8 @@ public class Batch extends BaseService {
     /**
      * Sends up to 100 batch emails.
      *
-     * <p>Each email supports the same options as single sends, including
-     * {@code scheduled_at}, {@code tags}, and {@code attachments}.
+     * <p>Each email supports standard send options plus {@code tags}.
+     * {@code attachments} and {@code scheduled_at} are not supported for batch emails.
      *
      * @param emails batch emails to send.
      * @param requestOptions The options with additional headers.

--- a/src/main/java/com/resend/services/batch/Batch.java
+++ b/src/main/java/com/resend/services/batch/Batch.java
@@ -33,6 +33,9 @@ public class Batch extends BaseService {
     /**
      * Sends up to 100 batch emails.
      *
+     * <p>Each email supports the same options as single sends, including
+     * {@code scheduled_at}, {@code tags}, and {@code attachments}.
+     *
      * @param emails batch emails to send.
      * @return The emails ids.
      * @throws ResendException If an error occurs while sending batch emails.
@@ -53,6 +56,9 @@ public class Batch extends BaseService {
 
     /**
      * Sends up to 100 batch emails.
+     *
+     * <p>Each email supports the same options as single sends, including
+     * {@code scheduled_at}, {@code tags}, and {@code attachments}.
      *
      * @param emails batch emails to send.
      * @param requestOptions The options with additional headers.

--- a/src/test/java/com/resend/services/batch/BatchTest.java
+++ b/src/test/java/com/resend/services/batch/BatchTest.java
@@ -52,7 +52,7 @@ public class BatchTest {
     }
 
     @Test
-    public void testCreateBatchEmails_SerializesScheduledAtTagsAndAttachments() throws ResendException {
+    public void testCreateBatchEmails_SerializesTags() throws ResendException {
         List<CreateEmailOptions> batchEmailsRequest = EmailsUtil.createBatchEmailOptions();
         ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
         AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, BATCH_RESPONSE_JSON, true);
@@ -63,9 +63,9 @@ public class BatchTest {
         batch.send(batchEmailsRequest);
 
         String payload = payloadCaptor.getValue();
-        assertTrue(payload.contains("\"scheduled_at\":\"2024-08-20T11:52:01.858Z\""));
         assertTrue(payload.contains("\"tags\":[{\"name\":\"tagName\",\"value\":\"tagValue\"}]"));
-        assertTrue(payload.contains("\"attachments\":[{\"filename\":\"invoice.pdf\",\"content\":\"invoice.pdf\",\"content_type\":\"pdf\",\"content_id\":\"my-image\"}]"));
+        assertFalse(payload.contains("attachments"));
+        assertFalse(payload.contains("scheduled_at"));
     }
 
     @Test

--- a/src/test/java/com/resend/services/batch/BatchTest.java
+++ b/src/test/java/com/resend/services/batch/BatchTest.java
@@ -64,8 +64,6 @@ public class BatchTest {
 
         String payload = payloadCaptor.getValue();
         assertTrue(payload.contains("\"tags\":[{\"name\":\"tagName\",\"value\":\"tagValue\"}]"));
-        assertFalse(payload.contains("attachments"));
-        assertFalse(payload.contains("scheduled_at"));
     }
 
     @Test

--- a/src/test/java/com/resend/services/batch/BatchTest.java
+++ b/src/test/java/com/resend/services/batch/BatchTest.java
@@ -12,6 +12,7 @@ import okhttp3.MediaType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -48,6 +49,23 @@ public class BatchTest {
     @AfterEach
     public void tearDown() throws Exception {
         mocks.close();
+    }
+
+    @Test
+    public void testCreateBatchEmails_SerializesScheduledAtTagsAndAttachments() throws ResendException {
+        List<CreateEmailOptions> batchEmailsRequest = EmailsUtil.createBatchEmailOptions();
+        ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, BATCH_RESPONSE_JSON, true);
+
+        when(httpClient.perform(eq("/emails/batch"), anyString(), eq(HttpMethod.POST), payloadCaptor.capture(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        batch.send(batchEmailsRequest);
+
+        String payload = payloadCaptor.getValue();
+        assertTrue(payload.contains("\"scheduled_at\":\"2024-08-20T11:52:01.858Z\""));
+        assertTrue(payload.contains("\"tags\":[{\"name\":\"tagName\",\"value\":\"tagValue\"}]"));
+        assertTrue(payload.contains("\"attachments\":[{\"filename\":\"invoice.pdf\",\"content\":\"invoice.pdf\",\"content_type\":\"pdf\",\"content_id\":\"my-image\"}]"));
     }
 
     @Test

--- a/src/test/java/com/resend/services/util/EmailsUtil.java
+++ b/src/test/java/com/resend/services/util/EmailsUtil.java
@@ -99,8 +99,21 @@ public class EmailsUtil {
         return new CancelEmailResponse("123", "emails");
     }
 
+    public static CreateEmailOptions createBatchEmailOption() {
+        return CreateEmailOptions.builder()
+                .from("Acme <onboarding@resend.dev>")
+                .to(Arrays.asList("example@resend.dev"))
+                .cc(Arrays.asList("example@resend.dev"))
+                .bcc(Arrays.asList("example@resend.dev"))
+                .replyTo(Arrays.asList("example@resend.dev", "example@resend.dev"))
+                .text("Hello, this is a batch email.")
+                .subject("Test batch email with tags")
+                .tags(Arrays.asList(createTag()))
+                .build();
+    }
+
     public static List<CreateEmailOptions> createBatchEmailOptions() {
-        return Arrays.asList(createEmailOptions(), createEmailOptions());
+        return Arrays.asList(createBatchEmailOption(), createBatchEmailOption());
     }
 
     public static CreateBatchEmailsResponse createBatchEmailsResponse() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The batch send API supports `tags` on individual emails. The Java SDK already models tags on `CreateEmailOptions`, which `Batch.send()` reuses. This change documents that support and adds a regression test that verifies tags are included in the serialized payload.

## Changes

- Document that batch emails support `tags` in `Batch.send()` javadoc
- Add `createBatchEmailOption()` test helper with tags
- Add `testCreateBatchEmails_SerializesTags` to assert the POST payload includes tags

## Test plan

- [x] `./gradlew test --tests "com.resend.services.batch.BatchTest"`
- [x] `./gradlew test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-148cc4fb-e8ff-4899-98c7-90989b96b476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-148cc4fb-e8ff-4899-98c7-90989b96b476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarify batch send behavior: only per-email `tags` are supported; `attachments` and `scheduled_at` are not. Update `Batch.send()` Javadoc and add a regression test verifying `tags` are included in the POST `/emails/batch` payload.

<sup>Written for commit 112250fd6a687bf5720331238c5317bd7367b27e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-java/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

