### PR TITLE
chore: update sync_prs_to_linear action hash to a54e4298f0

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@f6bdeec8e632f07b158cd1e3cd3ac70f59463288
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@a54e4298f03be11600192b1004b021501545f4c5
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
Update `sync_prs_to_linear` action hash to `a54e4298f03be11600192b1004b021501545f4c5`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `sync_prs_to_linear` GitHub Action pin to commit `a54e4298f03be11600192b1004b021501545f4c5` to pick up upstream fixes and keep runs reproducible. No functional changes expected.

<sup>Written for commit 6abe1fa192e8b280e51d47b81dd6695eba578d2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-java/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

