### PR TITLE
chore: use the API timestamp format in test fixtures

### DIFF
--- a/src/test/java/com/resend/services/apikeys/ApiKeysTest.java
+++ b/src/test/java/com/resend/services/apikeys/ApiKeysTest.java
@@ -25,9 +25,9 @@ public class ApiKeysTest {
 
     private static final String LIST_RESPONSE_JSON = "{\"data\":[" +
             "{\"id\":\"abcdefg-4321-5678-ijklmnop\",\"name\":\"Production\"," +
-            "\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"last_used_at\":\"2023-04-26T20:21:26.844Z\"}," +
+            "\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"last_used_at\":\"2023-04-26 20:21:26.844+00\"}," +
             "{\"id\":\"abcdefg-1234-5678-ijklmnop\",\"name\":\"Staging\"," +
-            "\"created_at\":\"2023-04-08T00:11:13.110779+00:00\"}" +
+            "\"created_at\":\"2023-04-08 00:11:13.110779+00\"}" +
             "],\"has_more\":true,\"object\":\"list\"}";
 
     @Mock

--- a/src/test/java/com/resend/services/audiences/AudiencesTest.java
+++ b/src/test/java/com/resend/services/audiences/AudiencesTest.java
@@ -27,16 +27,16 @@ public class AudiencesTest {
             "{\"id\":\"123\",\"name\":\"aud\",\"object\":\"audience\"}";
 
     private static final String LIST_RESPONSE_JSON = "{\"data\":[" +
-            "{\"id\":\"1\",\"name\":\"test1\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\"}," +
-            "{\"id\":\"2\",\"name\":\"test2\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\"}," +
-            "{\"id\":\"3\",\"name\":\"test3\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\"}" +
+            "{\"id\":\"1\",\"name\":\"test1\",\"created_at\":\"2023-04-08 00:11:13.110779+00\"}," +
+            "{\"id\":\"2\",\"name\":\"test2\",\"created_at\":\"2023-04-08 00:11:13.110779+00\"}," +
+            "{\"id\":\"3\",\"name\":\"test3\",\"created_at\":\"2023-04-08 00:11:13.110779+00\"}" +
             "],\"object\":\"list\",\"has_more\":true}";
 
     private static final String REMOVE_RESPONSE_JSON =
             "{\"id\":\"123\",\"object\":\"audience\",\"deleted\":true}";
 
     private static final String GET_RESPONSE_JSON =
-            "{\"id\":\"123\",\"name\":\"aud\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"object\":\"audience\"}";
+            "{\"id\":\"123\",\"name\":\"aud\",\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"object\":\"audience\"}";
 
     @Mock
     private IHttpClient httpClient;

--- a/src/test/java/com/resend/services/automations/AutomationsTest.java
+++ b/src/test/java/com/resend/services/automations/AutomationsTest.java
@@ -27,14 +27,14 @@ public class AutomationsTest {
     private static final String GET_AUTOMATION_JSON =
             "{\"object\":\"automation\",\"id\":\"" + AUTOMATION_ID + "\"," +
             "\"name\":\"Welcome Automation\",\"status\":\"enabled\"," +
-            "\"created_at\":\"2024-12-01T10:00:00.000Z\",\"updated_at\":\"2024-12-02T10:00:00.000Z\"," +
+            "\"created_at\":\"2024-12-01 10:00:00+00\",\"updated_at\":\"2024-12-02 10:00:00+00\"," +
             "\"steps\":[],\"connections\":[]}";
 
     private static final String LIST_AUTOMATIONS_JSON =
             "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
-            "{\"id\":\"1\",\"name\":\"Automation 1\",\"status\":\"enabled\",\"created_at\":\"2024-12-01T10:00:00.000Z\",\"updated_at\":\"2024-12-01T10:00:00.000Z\"}," +
-            "{\"id\":\"2\",\"name\":\"Automation 2\",\"status\":\"disabled\",\"created_at\":\"2024-12-02T10:00:00.000Z\",\"updated_at\":\"2024-12-02T10:00:00.000Z\"}," +
-            "{\"id\":\"3\",\"name\":\"Automation 3\",\"status\":\"enabled\",\"created_at\":\"2024-12-03T10:00:00.000Z\",\"updated_at\":\"2024-12-03T10:00:00.000Z\"}" +
+            "{\"id\":\"1\",\"name\":\"Automation 1\",\"status\":\"enabled\",\"created_at\":\"2024-12-01 10:00:00+00\",\"updated_at\":\"2024-12-01 10:00:00+00\"}," +
+            "{\"id\":\"2\",\"name\":\"Automation 2\",\"status\":\"disabled\",\"created_at\":\"2024-12-02 10:00:00+00\",\"updated_at\":\"2024-12-02 10:00:00+00\"}," +
+            "{\"id\":\"3\",\"name\":\"Automation 3\",\"status\":\"enabled\",\"created_at\":\"2024-12-03 10:00:00+00\",\"updated_at\":\"2024-12-03 10:00:00+00\"}" +
             "]}";
 
     private static final String UPDATE_AUTOMATION_JSON =
@@ -48,15 +48,15 @@ public class AutomationsTest {
 
     private static final String LIST_RUNS_JSON =
             "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
-            "{\"id\":\"run_1\",\"status\":\"completed\",\"started_at\":\"2024-12-01T10:00:00.000Z\",\"finished_at\":\"2024-12-01T10:05:00.000Z\",\"created_at\":\"2024-12-01T10:00:00.000Z\"}," +
-            "{\"id\":\"run_2\",\"status\":\"running\",\"started_at\":\"2024-12-02T10:00:00.000Z\",\"created_at\":\"2024-12-02T10:00:00.000Z\"}," +
-            "{\"id\":\"run_3\",\"status\":\"failed\",\"started_at\":\"2024-12-03T10:00:00.000Z\",\"finished_at\":\"2024-12-03T10:02:00.000Z\",\"created_at\":\"2024-12-03T10:00:00.000Z\"}" +
+            "{\"id\":\"run_1\",\"status\":\"completed\",\"started_at\":\"2024-12-01 10:00:00+00\",\"finished_at\":\"2024-12-01 10:05:00+00\",\"created_at\":\"2024-12-01 10:00:00+00\"}," +
+            "{\"id\":\"run_2\",\"status\":\"running\",\"started_at\":\"2024-12-02 10:00:00+00\",\"created_at\":\"2024-12-02 10:00:00+00\"}," +
+            "{\"id\":\"run_3\",\"status\":\"failed\",\"started_at\":\"2024-12-03 10:00:00+00\",\"finished_at\":\"2024-12-03 10:02:00+00\",\"created_at\":\"2024-12-03 10:00:00+00\"}" +
             "]}";
 
     private static final String GET_RUN_JSON =
             "{\"object\":\"automation_run\",\"id\":\"run_1\",\"status\":\"completed\"," +
-            "\"started_at\":\"2024-12-01T10:00:00.000Z\",\"finished_at\":\"2024-12-01T10:00:05.000Z\"," +
-            "\"created_at\":\"2024-12-01T10:00:00.000Z\",\"steps\":[]}";
+            "\"started_at\":\"2024-12-01 10:00:00+00\",\"finished_at\":\"2024-12-01 10:00:05+00\"," +
+            "\"created_at\":\"2024-12-01 10:00:00+00\",\"steps\":[]}";
 
     @Mock
     private IHttpClient httpClient;

--- a/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
+++ b/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
@@ -31,7 +31,7 @@ public class BroadcastsTest {
             "{\"id\":\"" + GET_BROADCAST_ID + "\"," +
             "\"audience_id\":\"" + AUDIENCE_ID + "\"," +
             "\"status\":\"draft\"," +
-            "\"created_at\":\"2024-12-01T19:32:22.980Z\"," +
+            "\"created_at\":\"2024-12-01 19:32:22.98+00\"," +
             "\"object\":\"broadcast\"," +
             "\"name\":\"Announcements\"," +
             "\"from\":\"Acme <onboarding@resend.dev>\"," +
@@ -44,9 +44,9 @@ public class BroadcastsTest {
 
     private static final String LIST_RESPONSE_JSON =
             "{\"object\":\"list\",\"has_more\":true,\"data\":[" +
-            "{\"id\":\"1\",\"audience_id\":\"" + AUDIENCE_ID + "\",\"status\":\"draft\",\"created_at\":\"2024-12-01T19:32:22.980Z\"}," +
-            "{\"id\":\"2\",\"audience_id\":\"" + AUDIENCE_ID + "\",\"status\":\"sent\",\"created_at\":\"2024-12-02T10:15:30.000Z\"}," +
-            "{\"id\":\"3\",\"audience_id\":\"" + AUDIENCE_ID + "\",\"status\":\"queued\",\"created_at\":\"2024-12-03T08:45:00.000Z\"}" +
+            "{\"id\":\"1\",\"audience_id\":\"" + AUDIENCE_ID + "\",\"status\":\"draft\",\"created_at\":\"2024-12-01 19:32:22.98+00\"}," +
+            "{\"id\":\"2\",\"audience_id\":\"" + AUDIENCE_ID + "\",\"status\":\"sent\",\"created_at\":\"2024-12-02 10:15:30+00\"}," +
+            "{\"id\":\"3\",\"audience_id\":\"" + AUDIENCE_ID + "\",\"status\":\"queued\",\"created_at\":\"2024-12-03 08:45:00+00\"}" +
             "]}";
 
     private static final String SEND_RESPONSE_JSON =

--- a/src/test/java/com/resend/services/contactproperties/ContactPropertiesTest.java
+++ b/src/test/java/com/resend/services/contactproperties/ContactPropertiesTest.java
@@ -21,14 +21,14 @@ public class ContactPropertiesTest {
 
     private static final String CREATE_RESPONSE_JSON = "{\"id\":\"123\",\"object\":\"contact_property\"}";
     private static final String GET_RESPONSE_JSON =
-            "{\"id\":\"123\",\"key\":\"age\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"type\":\"number\",\"fallback_value\":\"25\"}";
+            "{\"id\":\"123\",\"key\":\"age\",\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"type\":\"number\",\"fallback_value\":\"25\"}";
     private static final String UPDATE_RESPONSE_JSON = "{\"id\":\"123\",\"object\":\"contact_property\"}";
     private static final String REMOVE_RESPONSE_JSON = "{\"id\":\"123\",\"object\":\"contact_property\",\"deleted\":true}";
     private static final String LIST_RESPONSE_JSON =
             "{\"data\":[" +
-            "{\"id\":\"1\",\"key\":\"age\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"type\":\"string\",\"fallback_value\":\"25\"}," +
-            "{\"id\":\"2\",\"key\":\"city\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"type\":\"string\",\"fallback_value\":\"New York\"}," +
-            "{\"id\":\"3\",\"key\":\"subscribed\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"type\":\"string\",\"fallback_value\":\"fallback\"}" +
+            "{\"id\":\"1\",\"key\":\"age\",\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"type\":\"string\",\"fallback_value\":\"25\"}," +
+            "{\"id\":\"2\",\"key\":\"city\",\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"type\":\"string\",\"fallback_value\":\"New York\"}," +
+            "{\"id\":\"3\",\"key\":\"subscribed\",\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"type\":\"string\",\"fallback_value\":\"fallback\"}" +
             "],\"object\":\"list\",\"has_more\":false}";
 
     @Mock

--- a/src/test/java/com/resend/services/contacts/ContactSegmentsTest.java
+++ b/src/test/java/com/resend/services/contacts/ContactSegmentsTest.java
@@ -27,8 +27,8 @@ public class ContactSegmentsTest {
     private static final String REMOVE_SEGMENT_JSON = "{\"id\":\"" + SEGMENT_ID + "\",\"deleted\":true}";
     private static final String LIST_SEGMENTS_JSON =
             "{\"object\":\"list\",\"data\":[" +
-            "{\"id\":\"" + SEGMENT_ID + "\",\"name\":\"Registered Users\",\"created_at\":\"2023-10-06T22:59:55.977Z\"}," +
-            "{\"id\":\"b9d24c8e-bf1c-5d4d-cf1d-470cbd97482f\",\"name\":\"Premium Users\",\"created_at\":\"2023-11-12T14:23:10.123Z\"}" +
+            "{\"id\":\"" + SEGMENT_ID + "\",\"name\":\"Registered Users\",\"created_at\":\"2023-10-06 22:59:55.977+00\"}," +
+            "{\"id\":\"b9d24c8e-bf1c-5d4d-cf1d-470cbd97482f\",\"name\":\"Premium Users\",\"created_at\":\"2023-11-12 14:23:10.123+00\"}" +
             "],\"has_more\":false}";
 
     @Mock

--- a/src/test/java/com/resend/services/contacts/ContactsTest.java
+++ b/src/test/java/com/resend/services/contacts/ContactsTest.java
@@ -26,15 +26,15 @@ public class ContactsTest {
     private static final String GET_CONTACT_JSON =
             "{\"object\":\"contacts\",\"id\":\"123\",\"email\":\"user@example.com\"," +
             "\"first_name\":\"test\",\"last_name\":\"test\"," +
-            "\"created_at\":\"2025-04-30T12:00:00Z\",\"unsubscribed\":false}";
+            "\"created_at\":\"2025-04-30 12:00:00+00\",\"unsubscribed\":false}";
     private static final String LIST_CONTACTS_JSON =
             "{\"data\":[" +
             "{\"id\":\"1\",\"email\":\"frodo.baggins@shire.com\",\"first_name\":\"Frodo\"," +
-            "\"last_name\":\"Baggins\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"unsubscribed\":false}," +
+            "\"last_name\":\"Baggins\",\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"unsubscribed\":false}," +
             "{\"id\":\"2\",\"email\":\"aragorn.strider@gondor.com\",\"first_name\":\"Aragorn\"," +
-            "\"last_name\":\"Strider\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"unsubscribed\":false}," +
+            "\"last_name\":\"Strider\",\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"unsubscribed\":false}," +
             "{\"id\":\"3\",\"email\":\"legolas.greenleaf@woodland.com\",\"first_name\":\"Legolas\"," +
-            "\"last_name\":\"Greenleaf\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"unsubscribed\":false}" +
+            "\"last_name\":\"Greenleaf\",\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"unsubscribed\":false}" +
             "],\"object\":\"list\"}";
     private static final String UPDATE_TOPICS_JSON =
             "{\"id\":\"e169aa45-1ecf-4183-9955-b1499d5701d3\"}";

--- a/src/test/java/com/resend/services/domains/DomainsTest.java
+++ b/src/test/java/com/resend/services/domains/DomainsTest.java
@@ -23,12 +23,12 @@ public class DomainsTest {
 
     private static final String CREATE_RESPONSE_JSON =
             "{\"id\":\"" + DOMAIN_ID + "\",\"name\":\"resend.dev\"," +
-            "\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"status\":\"Active\"," +
+            "\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"status\":\"Active\"," +
             "\"region\":\"us-east-1\",\"dnsProvider\":\"DNSProviderXYZ\",\"records\":[]}";
 
     private static final String GET_RESPONSE_JSON =
             "{\"id\":\"" + DOMAIN_ID + "\",\"name\":\"resend.dev\"," +
-            "\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"status\":\"Active\"," +
+            "\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"status\":\"Active\"," +
             "\"region\":\"us-east-1\",\"dnsProvider\":\"DNSProviderXYZ\",\"object\":\"domain\",\"records\":[]}";
 
     private static final String VERIFY_RESPONSE_JSON =
@@ -41,11 +41,11 @@ public class DomainsTest {
             "{\"id\":\"" + DOMAIN_ID + "\",\"object\":\"domain\"}";
 
     private static final String LIST_RESPONSE_JSON = "{\"data\":[" +
-            "{\"id\":\"id-1\",\"name\":\"resend.dev\",\"created_at\":\"2023-04-08T00:11:13.110Z\"," +
+            "{\"id\":\"id-1\",\"name\":\"resend.dev\",\"created_at\":\"2023-04-08 00:11:13.11+00\"," +
             "\"status\":\"Active\",\"region\":\"us-east-1\"}," +
-            "{\"id\":\"id-2\",\"name\":\"example.com\",\"created_at\":\"2023-01-01T12:00:00.000Z\"," +
+            "{\"id\":\"id-2\",\"name\":\"example.com\",\"created_at\":\"2023-01-01 12:00:00+00\"," +
             "\"status\":\"Active\",\"region\":\"us-east-2\"}," +
-            "{\"id\":\"id-3\",\"name\":\"another.com\",\"created_at\":\"2023-02-15T08:30:00.000Z\"," +
+            "{\"id\":\"id-3\",\"name\":\"another.com\",\"created_at\":\"2023-02-15 08:30:00+00\"," +
             "\"status\":\"Inactive\",\"region\":\"us-west-1\"}" +
             "],\"has_more\":true,\"object\":\"list\"}";
 

--- a/src/test/java/com/resend/services/emails/EmailsTest.java
+++ b/src/test/java/com/resend/services/emails/EmailsTest.java
@@ -31,7 +31,7 @@ public class EmailsTest {
     private static final String GET_EMAIL_JSON =
             "{\"object\":\"email_object\",\"id\":\"" + EMAIL_ID + "\"," +
             "\"from\":\"sender@example.com\",\"to\":[\"recipient@example.com\"]," +
-            "\"created_at\":\"2023-04-08T00:11:13.110779+00:00\"," +
+            "\"created_at\":\"2023-04-08 00:11:13.110779+00\"," +
             "\"subject\":\"Test Email Subject\"," +
             "\"html\":\"<html><body>This is the HTML content</body></html>\"," +
             "\"text\":\"This is the plain text content\"," +

--- a/src/test/java/com/resend/services/events/EventsTest.java
+++ b/src/test/java/com/resend/services/events/EventsTest.java
@@ -29,13 +29,13 @@ public class EventsTest {
             "{\"object\":\"event\",\"id\":\"" + EVENT_ID + "\"," +
             "\"name\":\"user.signup\"," +
             "\"schema\":{\"user_id\":\"string\",\"plan\":\"string\"}," +
-            "\"created_at\":\"2024-12-01T10:00:00.000Z\",\"updated_at\":\"2024-12-02T10:00:00.000Z\"}";
+            "\"created_at\":\"2024-12-01 10:00:00+00\",\"updated_at\":\"2024-12-02 10:00:00+00\"}";
 
     private static final String LIST_EVENTS_JSON =
             "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
-            "{\"id\":\"1\",\"name\":\"user.signup\",\"created_at\":\"2024-12-01T10:00:00.000Z\"}," +
-            "{\"id\":\"2\",\"name\":\"user.verified\",\"created_at\":\"2024-12-02T10:00:00.000Z\"}," +
-            "{\"id\":\"3\",\"name\":\"order.created\",\"created_at\":\"2024-12-03T10:00:00.000Z\"}" +
+            "{\"id\":\"1\",\"name\":\"user.signup\",\"created_at\":\"2024-12-01 10:00:00+00\"}," +
+            "{\"id\":\"2\",\"name\":\"user.verified\",\"created_at\":\"2024-12-02 10:00:00+00\"}," +
+            "{\"id\":\"3\",\"name\":\"order.created\",\"created_at\":\"2024-12-03 10:00:00+00\"}" +
             "]}";
 
     private static final String UPDATE_EVENT_JSON =

--- a/src/test/java/com/resend/services/logs/LogsTest.java
+++ b/src/test/java/com/resend/services/logs/LogsTest.java
@@ -21,15 +21,15 @@ import static org.mockito.Mockito.when;
 public class LogsTest {
 
     private static final String GET_LOG_JSON =
-            "{\"id\":\"log_123\",\"created_at\":\"2024-01-01T00:00:00.000Z\"," +
+            "{\"id\":\"log_123\",\"created_at\":\"2024-01-01 00:00:00+00\"," +
             "\"endpoint\":\"/emails\",\"method\":\"POST\",\"response_status\":200," +
             "\"user_agent\":\"resend-java/4.13.0\",\"object\":\"log\"}";
 
     private static final String LIST_LOGS_JSON =
             "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
-            "{\"id\":\"log_1\",\"created_at\":\"2024-01-01T00:00:00.000Z\",\"endpoint\":\"/emails\",\"method\":\"POST\",\"response_status\":200,\"user_agent\":\"resend-java/4.13.0\"}," +
-            "{\"id\":\"log_2\",\"created_at\":\"2024-01-02T00:00:00.000Z\",\"endpoint\":\"/domains\",\"method\":\"GET\",\"response_status\":200,\"user_agent\":\"resend-java/4.13.0\"}," +
-            "{\"id\":\"log_3\",\"created_at\":\"2024-01-03T00:00:00.000Z\",\"endpoint\":\"/contacts\",\"method\":\"DELETE\",\"response_status\":204}" +
+            "{\"id\":\"log_1\",\"created_at\":\"2024-01-01 00:00:00+00\",\"endpoint\":\"/emails\",\"method\":\"POST\",\"response_status\":200,\"user_agent\":\"resend-java/4.13.0\"}," +
+            "{\"id\":\"log_2\",\"created_at\":\"2024-01-02 00:00:00+00\",\"endpoint\":\"/domains\",\"method\":\"GET\",\"response_status\":200,\"user_agent\":\"resend-java/4.13.0\"}," +
+            "{\"id\":\"log_3\",\"created_at\":\"2024-01-03 00:00:00+00\",\"endpoint\":\"/contacts\",\"method\":\"DELETE\",\"response_status\":204}" +
             "]}";
 
     @Mock

--- a/src/test/java/com/resend/services/receiving/ReceivingTest.java
+++ b/src/test/java/com/resend/services/receiving/ReceivingTest.java
@@ -26,7 +26,7 @@ public class ReceivingTest {
             "{\"object\":\"email\",\"id\":\"" + EMAIL_ID + "\"," +
             "\"to\":[\"delivered@resend.dev\"]," +
             "\"from\":\"Acme <onboarding@resend.dev>\"," +
-            "\"created_at\":\"2023-04-03T22:13:42.674981+00:00\"," +
+            "\"created_at\":\"2023-04-03 22:13:42.674981+00\"," +
             "\"subject\":\"Hello World\"," +
             "\"html\":\"Congrats on sending your <strong>first email</strong>!\"," +
             "\"bcc\":[],\"cc\":[],\"reply_to\":[]," +
@@ -52,7 +52,7 @@ public class ReceivingTest {
             "\"filename\":\"avatar.png\",\"content_type\":\"image/png\"," +
             "\"content_disposition\":\"inline\",\"content_id\":\"img001\"," +
             "\"download_url\":\"https://inbound-cdn.resend.com/" + EMAIL_ID + "/attachments/" + ATTACHMENT_ID + "?some-params=example&signature=sig-123\"," +
-            "\"expires_at\":\"2025-10-17T14:29:41.521Z\"}";
+            "\"expires_at\":\"2025-10-17 14:29:41.521+00\"}";
 
     private static final String LIST_ATTACHMENTS_JSON =
             "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
@@ -60,7 +60,7 @@ public class ReceivingTest {
             "\"filename\":\"avatar.png\",\"content_type\":\"image/png\"," +
             "\"content_disposition\":\"inline\",\"content_id\":\"img001\"," +
             "\"download_url\":\"https://inbound-cdn.resend.com/" + EMAIL_ID + "/attachments/" + ATTACHMENT_ID + "?some-params=example&signature=sig-123\"," +
-            "\"expires_at\":\"2025-10-17T14:29:41.521Z\"}" +
+            "\"expires_at\":\"2025-10-17 14:29:41.521+00\"}" +
             "]}";
 
     @Mock

--- a/src/test/java/com/resend/services/segments/SegmentsTest.java
+++ b/src/test/java/com/resend/services/segments/SegmentsTest.java
@@ -23,12 +23,12 @@ public class SegmentsTest {
     private static final String CREATE_RESPONSE_JSON = "{\"id\":\"123\",\"name\":\"seg\",\"object\":\"audience\"}";
     private static final String REMOVE_RESPONSE_JSON = "{\"id\":\"123\",\"object\":\"audience\",\"deleted\":true}";
     private static final String GET_RESPONSE_JSON =
-            "{\"id\":\"123\",\"name\":\"seg\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\",\"object\":\"audience\"}";
+            "{\"id\":\"123\",\"name\":\"seg\",\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"object\":\"audience\"}";
     private static final String LIST_RESPONSE_JSON =
             "{\"data\":[" +
-            "{\"id\":\"1\",\"name\":\"test1\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\"}," +
-            "{\"id\":\"2\",\"name\":\"test2\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\"}," +
-            "{\"id\":\"3\",\"name\":\"test3\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\"}" +
+            "{\"id\":\"1\",\"name\":\"test1\",\"created_at\":\"2023-04-08 00:11:13.110779+00\"}," +
+            "{\"id\":\"2\",\"name\":\"test2\",\"created_at\":\"2023-04-08 00:11:13.110779+00\"}," +
+            "{\"id\":\"3\",\"name\":\"test3\",\"created_at\":\"2023-04-08 00:11:13.110779+00\"}" +
             "],\"object\":\"list\",\"has_more\":true}";
 
     @Mock

--- a/src/test/java/com/resend/services/suppressions/SuppressionsTest.java
+++ b/src/test/java/com/resend/services/suppressions/SuppressionsTest.java
@@ -44,16 +44,16 @@ public class SuppressionsTest {
             "{\"object\":\"suppression\",\"id\":\"e169aa45-1ecf-4183-9955-b1499d5701d3\"," +
             "\"email\":\"steve.wozniak@example.com\",\"origin\":\"bounce\"," +
             "\"source_id\":\"4ef9a417-02e9-4d39-ad75-9611e0fcc33c\"," +
-            "\"created_at\":\"2026-10-06T23:47:56.678Z\"}";
+            "\"created_at\":\"2026-10-06 23:47:56.678+00\"}";
 
     private static final String LIST_RESPONSE_JSON = "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
             "{\"object\":\"suppression\",\"id\":\"e169aa45-1ecf-4183-9955-b1499d5701d3\"," +
             "\"email\":\"steve.wozniak@example.com\",\"origin\":\"manual\",\"source_id\":null," +
-            "\"created_at\":\"2026-10-06T23:47:56.678Z\"}," +
+            "\"created_at\":\"2026-10-06 23:47:56.678+00\"}," +
             "{\"object\":\"suppression\",\"id\":\"520784e2-887d-4c25-b53c-4ad46ad38100\"," +
             "\"email\":\"susan.kare@example.com\",\"origin\":\"bounce\"," +
             "\"source_id\":\"4ef9a417-02e9-4d39-ad75-9611e0fcc33c\"," +
-            "\"created_at\":\"2026-10-07T08:12:03.412Z\"}" +
+            "\"created_at\":\"2026-10-07 08:12:03.412+00\"}" +
             "]}";
 
     private static final String REMOVE_RESPONSE_JSON = "{\"data\":[" +
@@ -182,7 +182,7 @@ public class SuppressionsTest {
         assertEquals("steve.wozniak@example.com", response.getEmail());
         assertEquals("bounce", response.getOrigin());
         assertEquals("4ef9a417-02e9-4d39-ad75-9611e0fcc33c", response.getSourceId());
-        assertEquals("2026-10-06T23:47:56.678Z", response.getCreatedAt());
+        assertEquals("2026-10-06 23:47:56.678+00", response.getCreatedAt());
         assertEquals("suppression", response.getObject());
     }
 

--- a/src/test/java/com/resend/services/templates/TemplatesTest.java
+++ b/src/test/java/com/resend/services/templates/TemplatesTest.java
@@ -25,16 +25,16 @@ public class TemplatesTest {
     private static final String GET_RESPONSE_JSON =
             "{\"id\":\"" + TEMPLATE_ID + "\",\"object\":\"template\",\"alias\":\"reset-password\"," +
             "\"name\":\"reset-password\",\"status\":\"published\"," +
-            "\"created_at\":\"2023-10-06T23:47:56.678Z\",\"updated_at\":\"2023-10-06T23:47:56.678Z\"," +
-            "\"published_at\":\"2023-10-06T23:47:56.678Z\"," +
+            "\"created_at\":\"2023-10-06 23:47:56.678+00\",\"updated_at\":\"2023-10-06 23:47:56.678+00\"," +
+            "\"published_at\":\"2023-10-06 23:47:56.678+00\"," +
             "\"from\":\"John Doe <john.doe@example.com>\",\"subject\":\"Hello, world!\"," +
             "\"html\":\"<h1>Hello, world!</h1>\",\"text\":\"Hello, world!\",\"variables\":[]}";
     private static final String LIST_RESPONSE_JSON =
             "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
             "{\"id\":\"e169aa45-1ecf-4183-9955-b1499d5701d3\",\"name\":\"reset-password\",\"status\":\"draft\"," +
-            "\"alias\":\"reset-password\",\"created_at\":\"2023-10-06T23:47:56.678Z\",\"updated_at\":\"2023-10-06T23:47:56.678Z\"}," +
+            "\"alias\":\"reset-password\",\"created_at\":\"2023-10-06 23:47:56.678+00\",\"updated_at\":\"2023-10-06 23:47:56.678+00\"}," +
             "{\"id\":\"b7f9c2e1-1234-4abc-9def-567890abcdef\",\"name\":\"welcome-message\",\"status\":\"published\"," +
-            "\"alias\":\"welcome-message\",\"created_at\":\"2023-10-06T23:47:56.678Z\",\"updated_at\":\"2023-10-06T23:47:56.678Z\"}" +
+            "\"alias\":\"welcome-message\",\"created_at\":\"2023-10-06 23:47:56.678+00\",\"updated_at\":\"2023-10-06 23:47:56.678+00\"}" +
             "]}";
     private static final String UPDATE_RESPONSE_JSON = "{\"id\":\"" + TEMPLATE_ID + "\",\"object\":\"template\"}";
     private static final String DELETE_RESPONSE_JSON = "{\"object\":\"template\",\"id\":\"" + TEMPLATE_ID + "\",\"deleted\":true}";

--- a/src/test/java/com/resend/services/topics/TopicsTest.java
+++ b/src/test/java/com/resend/services/topics/TopicsTest.java
@@ -25,20 +25,20 @@ public class TopicsTest {
     private static final String GET_RESPONSE_JSON =
             "{\"id\":\"" + TOPIC_ID + "\",\"name\":\"Weekly Newsletter\"," +
             "\"description\":\"Weekly newsletter for our subscribers\"," +
-            "\"default_subscription\":\"opt_in\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\"}";
+            "\"default_subscription\":\"opt_in\",\"created_at\":\"2023-04-08 00:11:13.110779+00\"}";
     private static final String UPDATE_RESPONSE_JSON = "{\"id\":\"" + TOPIC_ID + "\"}";
     private static final String REMOVE_RESPONSE_JSON = "{\"object\":\"topic\",\"id\":\"" + TOPIC_ID + "\",\"deleted\":true}";
     private static final String LIST_RESPONSE_JSON =
             "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
             "{\"id\":\"" + TOPIC_ID + "\",\"name\":\"Weekly Newsletter\"," +
             "\"description\":\"Weekly newsletter for our subscribers\"," +
-            "\"default_subscription\":\"opt_in\",\"created_at\":\"2023-04-08T00:11:13.110779+00:00\"}," +
+            "\"default_subscription\":\"opt_in\",\"created_at\":\"2023-04-08 00:11:13.110779+00\"}," +
             "{\"id\":\"c7e35c9f-bg1c-5d4d-cf1d-460cce08492f\",\"name\":\"Monthly Updates\"," +
             "\"description\":\"Monthly updates and announcements\"," +
-            "\"default_subscription\":\"opt_out\",\"created_at\":\"2023-04-09T00:11:13.110779+00:00\"}," +
+            "\"default_subscription\":\"opt_out\",\"created_at\":\"2023-04-09 00:11:13.110779+00\"}," +
             "{\"id\":\"d8f46da0-ch2d-6e5e-dg2e-571ddf19503g\",\"name\":\"Product Launches\"," +
             "\"description\":\"Get notified about new product launches\"," +
-            "\"default_subscription\":\"opt_in\",\"created_at\":\"2023-04-10T00:11:13.110779+00:00\"}" +
+            "\"default_subscription\":\"opt_in\",\"created_at\":\"2023-04-10 00:11:13.110779+00\"}" +
             "]}";
 
     @Mock

--- a/src/test/java/com/resend/services/util/ApiKeysUtil.java
+++ b/src/test/java/com/resend/services/util/ApiKeysUtil.java
@@ -28,13 +28,13 @@ public class ApiKeysUtil {
         ApiKey apiKey1 = new ApiKey(
                 "abcdefg-4321-5678-ijklmnop",
                 "Production",
-                "2023-04-08T00:11:13.110779+00:00",
-                "2023-04-26T20:21:26.844Z");
+                "2023-04-08 00:11:13.110779+00",
+                "2023-04-26 20:21:26.844+00");
 
         ApiKey apiKey2 = new ApiKey(
                 "abcdefg-1234-5678-ijklmnop",
                 "Staging",
-                "2023-04-08T00:11:13.110779+00:00",
+                "2023-04-08 00:11:13.110779+00",
                 null);
 
         apiKeys.add(apiKey1);

--- a/src/test/java/com/resend/services/util/AudiencesUtil.java
+++ b/src/test/java/com/resend/services/util/AudiencesUtil.java
@@ -22,9 +22,9 @@ public class AudiencesUtil {
     public static ListAudiencesResponseSuccess createAudiencesListResponse() {
         List<Audience> audList = new ArrayList<>();
 
-        Audience aud1 = new Audience("1", "test1", "2023-04-08T00:11:13.110779+00:00");
-        Audience aud2 = new Audience("2", "test2", "2023-04-08T00:11:13.110779+00:00");
-        Audience aud3 = new Audience("3", "test3", "2023-04-08T00:11:13.110779+00:00");
+        Audience aud1 = new Audience("1", "test1", "2023-04-08 00:11:13.110779+00");
+        Audience aud2 = new Audience("2", "test2", "2023-04-08 00:11:13.110779+00");
+        Audience aud3 = new Audience("3", "test3", "2023-04-08 00:11:13.110779+00");
 
         audList.add(aud1);
         audList.add(aud2);

--- a/src/test/java/com/resend/services/util/AutomationsUtil.java
+++ b/src/test/java/com/resend/services/util/AutomationsUtil.java
@@ -63,8 +63,8 @@ public class AutomationsUtil {
                 "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
                 "Welcome Automation",
                 AutomationStatus.ENABLED,
-                "2024-12-01T10:00:00.000Z",
-                "2024-12-02T10:00:00.000Z",
+                "2024-12-01 10:00:00+00",
+                "2024-12-02 10:00:00+00",
                 Arrays.asList(triggerStep),
                 Arrays.asList(connection)
         );
@@ -72,9 +72,9 @@ public class AutomationsUtil {
 
     public static ListAutomationsResponseSuccess listAutomationsResponse() {
         List<AutomationListItem> automations = new ArrayList<>();
-        automations.add(new AutomationListItem("1", "Automation 1", AutomationStatus.ENABLED, "2024-12-01T10:00:00.000Z", "2024-12-01T10:00:00.000Z"));
-        automations.add(new AutomationListItem("2", "Automation 2", AutomationStatus.DISABLED, "2024-12-02T10:00:00.000Z", "2024-12-02T10:00:00.000Z"));
-        automations.add(new AutomationListItem("3", "Automation 3", AutomationStatus.ENABLED, "2024-12-03T10:00:00.000Z", "2024-12-03T10:00:00.000Z"));
+        automations.add(new AutomationListItem("1", "Automation 1", AutomationStatus.ENABLED, "2024-12-01 10:00:00+00", "2024-12-01 10:00:00+00"));
+        automations.add(new AutomationListItem("2", "Automation 2", AutomationStatus.DISABLED, "2024-12-02 10:00:00+00", "2024-12-02 10:00:00+00"));
+        automations.add(new AutomationListItem("3", "Automation 3", AutomationStatus.ENABLED, "2024-12-03 10:00:00+00", "2024-12-03 10:00:00+00"));
 
         return new ListAutomationsResponseSuccess("list", false, automations);
     }
@@ -89,24 +89,24 @@ public class AutomationsUtil {
 
     public static ListAutomationRunsResponseSuccess listAutomationRunsResponse() {
         List<AutomationRunListItem> runs = new ArrayList<>();
-        runs.add(new AutomationRunListItem("run_1", RunStatus.COMPLETED, "2024-12-01T10:00:00.000Z", "2024-12-01T10:05:00.000Z", "2024-12-01T10:00:00.000Z"));
-        runs.add(new AutomationRunListItem("run_2", RunStatus.RUNNING, "2024-12-02T10:00:00.000Z", null, "2024-12-02T10:00:00.000Z"));
-        runs.add(new AutomationRunListItem("run_3", RunStatus.FAILED, "2024-12-03T10:00:00.000Z", "2024-12-03T10:02:00.000Z", "2024-12-03T10:00:00.000Z"));
+        runs.add(new AutomationRunListItem("run_1", RunStatus.COMPLETED, "2024-12-01 10:00:00+00", "2024-12-01 10:05:00+00", "2024-12-01 10:00:00+00"));
+        runs.add(new AutomationRunListItem("run_2", RunStatus.RUNNING, "2024-12-02 10:00:00+00", null, "2024-12-02 10:00:00+00"));
+        runs.add(new AutomationRunListItem("run_3", RunStatus.FAILED, "2024-12-03 10:00:00+00", "2024-12-03 10:02:00+00", "2024-12-03 10:00:00+00"));
 
         return new ListAutomationRunsResponseSuccess("list", false, runs);
     }
 
     public static AutomationRun getAutomationRunResponse() {
-        AutomationRunStep step1 = new AutomationRunStep("trigger_1", StepType.TRIGGER, "completed", "2024-12-01T10:00:00.000Z", "2024-12-01T10:00:01.000Z", null, null, "2024-12-01T10:00:00.000Z");
-        AutomationRunStep step2 = new AutomationRunStep("email_1", StepType.SEND_EMAIL, "completed", "2024-12-01T10:00:01.000Z", "2024-12-01T10:00:05.000Z", null, null, "2024-12-01T10:00:01.000Z");
+        AutomationRunStep step1 = new AutomationRunStep("trigger_1", StepType.TRIGGER, "completed", "2024-12-01 10:00:00+00", "2024-12-01 10:00:01+00", null, null, "2024-12-01 10:00:00+00");
+        AutomationRunStep step2 = new AutomationRunStep("email_1", StepType.SEND_EMAIL, "completed", "2024-12-01 10:00:01+00", "2024-12-01 10:00:05+00", null, null, "2024-12-01 10:00:01+00");
 
         return new AutomationRun(
                 "automation_run",
                 "run_1",
                 RunStatus.COMPLETED,
-                "2024-12-01T10:00:00.000Z",
-                "2024-12-01T10:00:05.000Z",
-                "2024-12-01T10:00:00.000Z",
+                "2024-12-01 10:00:00+00",
+                "2024-12-01 10:00:05+00",
+                "2024-12-01 10:00:00+00",
                 Arrays.asList(step1, step2)
         );
     }

--- a/src/test/java/com/resend/services/util/BroadcastsUtil.java
+++ b/src/test/java/com/resend/services/util/BroadcastsUtil.java
@@ -52,7 +52,7 @@ public class BroadcastsUtil {
                 "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
                 "78261eea-8f8b-4381-83c6-79fa7120f1cf",
                 "draft",
-                "2024-12-01T19:32:22.980Z",
+                "2024-12-01 19:32:22.98+00",
                 null,
                 null,
                 "broadcast",
@@ -73,9 +73,9 @@ public class BroadcastsUtil {
     public static ListBroadcastsResponseSuccess createBroadcastsListResponse() {
         List<Broadcast> broadcastList = new ArrayList<>();
 
-        broadcastList.add(new Broadcast("1", "78261eea-8f8b-4381-83c6-79fa7120f1cf", "draft", "2024-12-01T19:32:22.980Z", null, null));
-        broadcastList.add(new Broadcast("2", "78261eea-8f8b-4381-83c6-79fa7120f1cf", "sent", "2024-12-02T10:15:30.000Z", "2024-12-02T11:00:00.000Z", "2024-12-02T12:00:00.000Z"));
-        broadcastList.add(new Broadcast("3", "78261eea-8f8b-4381-83c6-79fa7120f1cf", "queued", "2024-12-03T08:45:00.000Z", null, null));
+        broadcastList.add(new Broadcast("1", "78261eea-8f8b-4381-83c6-79fa7120f1cf", "draft", "2024-12-01 19:32:22.98+00", null, null));
+        broadcastList.add(new Broadcast("2", "78261eea-8f8b-4381-83c6-79fa7120f1cf", "sent", "2024-12-02 10:15:30+00", "2024-12-02 11:00:00+00", "2024-12-02 12:00:00+00"));
+        broadcastList.add(new Broadcast("3", "78261eea-8f8b-4381-83c6-79fa7120f1cf", "queued", "2024-12-03 08:45:00+00", null, null));
 
         return new ListBroadcastsResponseSuccess("list", broadcastList, true);
     }

--- a/src/test/java/com/resend/services/util/ContactPropertiesUtil.java
+++ b/src/test/java/com/resend/services/util/ContactPropertiesUtil.java
@@ -38,7 +38,7 @@ public class ContactPropertiesUtil {
         return new ContactProperty(
                 "123",
                 "age",
-                "2023-04-08T00:11:13.110779+00:00",
+                "2023-04-08 00:11:13.110779+00",
                 "number",
                 "25"
         );
@@ -47,9 +47,9 @@ public class ContactPropertiesUtil {
     public static ListContactPropertiesResponseSuccess createContactPropertiesListResponse() {
         List<ContactProperty> properties = new ArrayList<>();
 
-        ContactProperty p1 = new ContactProperty("1", "age", "2023-04-08T00:11:13.110779+00:00", "string", "25");
-        ContactProperty p2 = new ContactProperty("2", "city", "2023-04-08T00:11:13.110779+00:00", "string", "New York");
-        ContactProperty p3 = new ContactProperty("3", "subscribed", "2023-04-08T00:11:13.110779+00:00", "string", "fallback");
+        ContactProperty p1 = new ContactProperty("1", "age", "2023-04-08 00:11:13.110779+00", "string", "25");
+        ContactProperty p2 = new ContactProperty("2", "city", "2023-04-08 00:11:13.110779+00", "string", "New York");
+        ContactProperty p3 = new ContactProperty("3", "subscribed", "2023-04-08 00:11:13.110779+00", "string", "fallback");
 
         properties.add(p1);
         properties.add(p2);

--- a/src/test/java/com/resend/services/util/ContactsUtil.java
+++ b/src/test/java/com/resend/services/util/ContactsUtil.java
@@ -25,9 +25,9 @@ public class ContactsUtil {
     public static ListContactsResponseSuccess createContactsListResponse() {
         List<Contact> contacts = new ArrayList<>();
 
-        Contact c1 = new Contact("1", "frodo.baggins@shire.com", "Frodo", "Baggins", "2023-04-08T00:11:13.110779+00:00", false);
-        Contact c2 = new Contact("2", "aragorn.strider@gondor.com", "Aragorn", "Strider", "2023-04-08T00:11:13.110779+00:00", false);
-        Contact c3 = new Contact("3", "legolas.greenleaf@woodland.com", "Legolas", "Greenleaf", "2023-04-08T00:11:13.110779+00:00", false);
+        Contact c1 = new Contact("1", "frodo.baggins@shire.com", "Frodo", "Baggins", "2023-04-08 00:11:13.110779+00", false);
+        Contact c2 = new Contact("2", "aragorn.strider@gondor.com", "Aragorn", "Strider", "2023-04-08 00:11:13.110779+00", false);
+        Contact c3 = new Contact("3", "legolas.greenleaf@woodland.com", "Legolas", "Greenleaf", "2023-04-08 00:11:13.110779+00", false);
 
 
         contacts.add(c1);
@@ -56,7 +56,7 @@ public class ContactsUtil {
                 "user@example.com",
                 "test",
                 "test",
-                "2025-04-30T12:00:00Z",
+                "2025-04-30 12:00:00+00",
                 false
         );
     }
@@ -137,12 +137,12 @@ public class ContactsUtil {
         ContactSegment seg1 = new ContactSegment(
                 "78261eea-8f8b-4381-83c6-79fa7120f1cf",
                 "Registered Users",
-                "2023-10-06T22:59:55.977Z"
+                "2023-10-06 22:59:55.977+00"
         );
         ContactSegment seg2 = new ContactSegment(
                 "b9d24c8e-bf1c-5d4d-cf1d-470cbd97482f",
                 "Premium Users",
-                "2023-11-12T14:23:10.123Z"
+                "2023-11-12 14:23:10.123+00"
         );
 
         segments.add(seg1);

--- a/src/test/java/com/resend/services/util/DomainsUtil.java
+++ b/src/test/java/com/resend/services/util/DomainsUtil.java
@@ -23,7 +23,7 @@ public class DomainsUtil {
         DomainDTO domain1 = new DomainDTO(
                 "id-1",
                 "resend.dev",
-                "2023-04-08T00:11:13.110Z",
+                "2023-04-08 00:11:13.11+00",
                 "Active",
                 "us-east-1"
         );
@@ -31,7 +31,7 @@ public class DomainsUtil {
         DomainDTO domain2 = new DomainDTO(
                 "id-2",
                 "example.com",
-                "2023-01-01T12:00:00.000Z",
+                "2023-01-01 12:00:00+00",
                 "Active",
                 "us-east-2"
         );
@@ -39,7 +39,7 @@ public class DomainsUtil {
         DomainDTO domain3 = new DomainDTO(
                 "id-3",
                 "another.com",
-                "2023-02-15T08:30:00.000Z",
+                "2023-02-15 08:30:00+00",
                 "Inactive",
                 "us-west-1"
         );
@@ -55,7 +55,7 @@ public class DomainsUtil {
         return new CreateDomainResponse(
                 "2c64b27c-6237-4626-85d2-a0a8b5832070",
                 "resend.dev",
-                "2023-04-08T00:11:13.110779+00:00",
+                "2023-04-08 00:11:13.110779+00",
                 "Active",
                 "us-east-1",
                 "DNSProviderXYZ",
@@ -66,7 +66,7 @@ public class DomainsUtil {
     public static final Domain createDomain() {
         return new Domain("2c64b27c-6237-4626-85d2-a0a8b5832070",
                 "resend.dev",
-                "2023-04-08T00:11:13.110779+00:00",
+                "2023-04-08 00:11:13.110779+00",
                 "Active",
                 "us-east-1",
                 "DNSProviderXYZ",

--- a/src/test/java/com/resend/services/util/EmailsUtil.java
+++ b/src/test/java/com/resend/services/util/EmailsUtil.java
@@ -127,7 +127,7 @@ public class EmailsUtil {
                 "qwert",
                 "sender@example.com",
                 Arrays.asList("recipient@example.com"),
-                "2023-04-08T00:11:13.110779+00:00",
+                "2023-04-08 00:11:13.110779+00",
                 "Test Email Subject",
                 "<html><body>This is the HTML content</body></html>",
                 "This is the plain text content",
@@ -146,7 +146,7 @@ public class EmailsUtil {
                 "qwert1",
                 "sender1@example.com",
                 Arrays.asList("recipient1@example.com"),
-                "2023-04-08T00:11:13.110779+00:00",
+                "2023-04-08 00:11:13.110779+00",
                 "Test Email Subject 1",
                 "<html><body>This is the HTML content 1</body></html>",
                 "This is the plain text content 1",
@@ -161,7 +161,7 @@ public class EmailsUtil {
                 "qwert2",
                 "sender2@example.com",
                 Arrays.asList("recipient2@example.com"),
-                "2023-04-09T00:11:13.110779+00:00",
+                "2023-04-09 00:11:13.110779+00",
                 "Test Email Subject 2",
                 "<html><body>This is the HTML content 2</body></html>",
                 "This is the plain text content 2",
@@ -176,7 +176,7 @@ public class EmailsUtil {
                 "qwert3",
                 "sender3@example.com",
                 Arrays.asList("recipient3@example.com"),
-                "2023-04-10T00:11:13.110779+00:00",
+                "2023-04-10 00:11:13.110779+00",
                 "Test Email Subject 3",
                 "<html><body>This is the HTML content 3</body></html>",
                 "This is the plain text content 3",
@@ -208,7 +208,7 @@ public class EmailsUtil {
         response.setContentDisposition("inline");
         response.setContentId("img001");
         response.setDownloadUrl("https://outbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123");
-        response.setExpiresAt("2025-10-17T14:29:41.521Z");
+        response.setExpiresAt("2025-10-17 14:29:41.521+00");
         return response;
     }
 
@@ -224,7 +224,7 @@ public class EmailsUtil {
         attachment1.setContentDisposition("inline");
         attachment1.setContentId("img001");
         attachment1.setDownloadUrl("https://outbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123");
-        attachment1.setExpiresAt("2025-10-17T14:29:41.521Z");
+        attachment1.setExpiresAt("2025-10-17 14:29:41.521+00");
 
         AttachmentResponse attachment2 = new AttachmentResponse();
         attachment2.setObject("attachment");
@@ -235,7 +235,7 @@ public class EmailsUtil {
         attachment2.setContentDisposition("attachment");
         attachment2.setContentId("doc001");
         attachment2.setDownloadUrl("https://outbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/3b0d9ce0-4223-5839-087f-58eede27b429?some-params=example&signature=sig-456");
-        attachment2.setExpiresAt("2025-10-17T14:29:41.521Z");
+        attachment2.setExpiresAt("2025-10-17 14:29:41.521+00");
 
         attachments.add(attachment1);
         attachments.add(attachment2);

--- a/src/test/java/com/resend/services/util/EventsUtil.java
+++ b/src/test/java/com/resend/services/util/EventsUtil.java
@@ -34,16 +34,16 @@ public class EventsUtil {
                 "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
                 "user.signup",
                 schema,
-                "2024-12-01T10:00:00.000Z",
-                "2024-12-02T10:00:00.000Z"
+                "2024-12-01 10:00:00+00",
+                "2024-12-02 10:00:00+00"
         );
     }
 
     public static ListEventsResponseSuccess listEventsResponse() {
         List<EventSummary> events = new ArrayList<>();
-        events.add(new EventSummary("1", "user.signup", null, "2024-12-01T10:00:00.000Z", null));
-        events.add(new EventSummary("2", "user.verified", null, "2024-12-02T10:00:00.000Z", null));
-        events.add(new EventSummary("3", "order.created", null, "2024-12-03T10:00:00.000Z", null));
+        events.add(new EventSummary("1", "user.signup", null, "2024-12-01 10:00:00+00", null));
+        events.add(new EventSummary("2", "user.verified", null, "2024-12-02 10:00:00+00", null));
+        events.add(new EventSummary("3", "order.created", null, "2024-12-03 10:00:00+00", null));
 
         return new ListEventsResponseSuccess("list", false, events);
     }

--- a/src/test/java/com/resend/services/util/LogsUtil.java
+++ b/src/test/java/com/resend/services/util/LogsUtil.java
@@ -12,7 +12,7 @@ public class LogsUtil {
     public static GetLogResponseSuccess getLogResponseSuccess() {
         return new GetLogResponseSuccess(
                 "log_123",
-                "2024-01-01T00:00:00.000Z",
+                "2024-01-01 00:00:00+00",
                 "/emails",
                 "POST",
                 200,
@@ -25,9 +25,9 @@ public class LogsUtil {
 
     public static ListLogsResponseSuccess createLogsListResponse() {
         List<LogEntry> entries = new ArrayList<>();
-        entries.add(new LogEntry("log_1", "2024-01-01T00:00:00.000Z", "/emails", "POST", 200, "resend-java/4.13.0"));
-        entries.add(new LogEntry("log_2", "2024-01-02T00:00:00.000Z", "/domains", "GET", 200, "resend-java/4.13.0"));
-        entries.add(new LogEntry("log_3", "2024-01-03T00:00:00.000Z", "/contacts", "DELETE", 204, null));
+        entries.add(new LogEntry("log_1", "2024-01-01 00:00:00+00", "/emails", "POST", 200, "resend-java/4.13.0"));
+        entries.add(new LogEntry("log_2", "2024-01-02 00:00:00+00", "/domains", "GET", 200, "resend-java/4.13.0"));
+        entries.add(new LogEntry("log_3", "2024-01-03 00:00:00+00", "/contacts", "DELETE", 204, null));
         return new ListLogsResponseSuccess("list", false, entries);
     }
 }

--- a/src/test/java/com/resend/services/util/ReceivingUtil.java
+++ b/src/test/java/com/resend/services/util/ReceivingUtil.java
@@ -24,7 +24,7 @@ public class ReceivingUtil {
         email.setId("4ef9a417-02e9-4d39-ad75-9611e0fcc33c");
         email.setTo(Arrays.asList("delivered@resend.dev"));
         email.setFrom("Acme <onboarding@resend.dev>");
-        email.setCreatedAt("2023-04-03T22:13:42.674981+00:00");
+        email.setCreatedAt("2023-04-03 22:13:42.674981+00");
         email.setSubject("Hello World");
         email.setHtml("Congrats on sending your <strong>first email</strong>!");
         email.setText(null);
@@ -108,7 +108,7 @@ public class ReceivingUtil {
         details.setContentDisposition("inline");
         details.setContentId("img001");
         details.setDownloadUrl("https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123");
-        details.setExpiresAt("2025-10-17T14:29:41.521Z");
+        details.setExpiresAt("2025-10-17 14:29:41.521+00");
         return details;
     }
 

--- a/src/test/java/com/resend/services/util/SegmentsUtil.java
+++ b/src/test/java/com/resend/services/util/SegmentsUtil.java
@@ -22,9 +22,9 @@ public class SegmentsUtil {
     public static ListSegmentsResponseSuccess createSegmentsListResponse() {
         List<Segment> segList = new ArrayList<>();
 
-        Segment seg1 = new Segment("1", "test1", "2023-04-08T00:11:13.110779+00:00");
-        Segment seg2 = new Segment("2", "test2", "2023-04-08T00:11:13.110779+00:00");
-        Segment seg3 = new Segment("3", "test3", "2023-04-08T00:11:13.110779+00:00");
+        Segment seg1 = new Segment("1", "test1", "2023-04-08 00:11:13.110779+00");
+        Segment seg2 = new Segment("2", "test2", "2023-04-08 00:11:13.110779+00");
+        Segment seg3 = new Segment("3", "test3", "2023-04-08 00:11:13.110779+00");
 
         segList.add(seg1);
         segList.add(seg2);
@@ -34,6 +34,6 @@ public class SegmentsUtil {
     }
 
     public static GetSegmentResponseSuccess getSegmentResponseSuccess() {
-        return new GetSegmentResponseSuccess("123", "seg", "2023-04-08T00:11:13.110779+00:00", "audience");
+        return new GetSegmentResponseSuccess("123", "seg", "2023-04-08 00:11:13.110779+00", "audience");
     }
 }

--- a/src/test/java/com/resend/services/util/TemplatesUtil.java
+++ b/src/test/java/com/resend/services/util/TemplatesUtil.java
@@ -135,10 +135,10 @@ public class TemplatesUtil {
         template.setId("34a080c9-b17d-4187-ad80-5af20266e535");
         template.setAlias("reset-password");
         template.setName("reset-password");
-        template.setCreatedAt("2023-10-06T23:47:56.678Z");
-        template.setUpdatedAt("2023-10-06T23:47:56.678Z");
+        template.setCreatedAt("2023-10-06 23:47:56.678+00");
+        template.setUpdatedAt("2023-10-06 23:47:56.678+00");
         template.setStatus("published");
-        template.setPublishedAt("2023-10-06T23:47:56.678Z");
+        template.setPublishedAt("2023-10-06 23:47:56.678+00");
         template.setFrom("John Doe <john.doe@example.com>");
         template.setSubject("Hello, world!");
         template.setReplyTo(null);
@@ -150,8 +150,8 @@ public class TemplatesUtil {
         variable.setKey("user_name");
         variable.setType(VariableType.STRING);
         variable.setFallbackValue("John Doe");
-        variable.setCreatedAt("2023-10-06T23:47:56.678Z");
-        variable.setUpdatedAt("2023-10-06T23:47:56.678Z");
+        variable.setCreatedAt("2023-10-06 23:47:56.678+00");
+        variable.setUpdatedAt("2023-10-06 23:47:56.678+00");
 
         template.setVariables(Arrays.asList(variable));
 
@@ -169,8 +169,8 @@ public class TemplatesUtil {
         item.setName("reset-password");
         item.setStatus("draft");
         item.setPublishedAt(null);
-        item.setCreatedAt("2023-10-06T23:47:56.678Z");
-        item.setUpdatedAt("2023-10-06T23:47:56.678Z");
+        item.setCreatedAt("2023-10-06 23:47:56.678+00");
+        item.setUpdatedAt("2023-10-06 23:47:56.678+00");
         item.setAlias("reset-password");
         return item;
     }
@@ -185,9 +185,9 @@ public class TemplatesUtil {
         item.setId("b7f9c2e1-1234-4abc-9def-567890abcdef");
         item.setName("welcome-message");
         item.setStatus("published");
-        item.setPublishedAt("2023-10-06T23:47:56.678Z");
-        item.setCreatedAt("2023-10-06T23:47:56.678Z");
-        item.setUpdatedAt("2023-10-06T23:47:56.678Z");
+        item.setPublishedAt("2023-10-06 23:47:56.678+00");
+        item.setCreatedAt("2023-10-06 23:47:56.678+00");
+        item.setUpdatedAt("2023-10-06 23:47:56.678+00");
         item.setAlias("welcome-message");
         return item;
     }

--- a/src/test/java/com/resend/services/util/TopicsUtil.java
+++ b/src/test/java/com/resend/services/util/TopicsUtil.java
@@ -73,7 +73,7 @@ public class TopicsUtil {
                 "Weekly Newsletter",
                 "Weekly newsletter for our subscribers",
                 "opt_in",
-                "2023-04-08T00:11:13.110779+00:00"
+                "2023-04-08 00:11:13.110779+00"
         );
     }
 
@@ -90,7 +90,7 @@ public class TopicsUtil {
                 "Weekly Newsletter",
                 "Weekly newsletter for our subscribers",
                 "opt_in",
-                "2023-04-08T00:11:13.110779+00:00"
+                "2023-04-08 00:11:13.110779+00"
         ));
 
         topics.add(new Topic(
@@ -98,7 +98,7 @@ public class TopicsUtil {
                 "Monthly Updates",
                 "Monthly updates and announcements",
                 "opt_out",
-                "2023-04-09T00:11:13.110779+00:00"
+                "2023-04-09 00:11:13.110779+00"
         ));
 
         topics.add(new Topic(
@@ -106,7 +106,7 @@ public class TopicsUtil {
                 "Product Launches",
                 "Get notified about new product launches",
                 "opt_in",
-                "2023-04-10T00:11:13.110779+00:00"
+                "2023-04-10 00:11:13.110779+00"
         ));
 
         return topics;

--- a/src/test/java/com/resend/services/util/WebhooksUtil.java
+++ b/src/test/java/com/resend/services/util/WebhooksUtil.java
@@ -50,7 +50,7 @@ public class WebhooksUtil {
         GetWebhookResponseSuccess webhook = new GetWebhookResponseSuccess();
         webhook.setObject("webhook");
         webhook.setId("4dd369bc-aa82-4ff3-97de-514ae3000ee0");
-        webhook.setCreatedAt("2023-08-22T15:28:00.000Z");
+        webhook.setCreatedAt("2023-08-22 15:28:00+00");
         webhook.setStatus(WebhookStatus.ENABLED);
         webhook.setEndpoint("https://webhook.example.com/handler");
         webhook.setEvents(Arrays.asList("email.sent", "email.received"));
@@ -63,7 +63,7 @@ public class WebhooksUtil {
 
         WebhookDTO webhook1 = new WebhookDTO(
                 "7ab123cd-ef45-6789-abcd-ef0123456789",
-                "2023-09-10T10:15:30.000Z",
+                "2023-09-10 10:15:30+00",
                 WebhookStatus.DISABLED,
                 "https://first-webhook.example.com/handler",
                 Arrays.asList("email.delivered", "email.bounced")
@@ -71,7 +71,7 @@ public class WebhooksUtil {
 
         WebhookDTO webhook2 = new WebhookDTO(
                 "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
-                "2023-08-22T15:28:00.000Z",
+                "2023-08-22 15:28:00+00",
                 WebhookStatus.ENABLED,
                 "https://second-webhook.example.com/receive",
                 Arrays.asList("email.received")

--- a/src/test/java/com/resend/services/webhooks/WebhooksTest.java
+++ b/src/test/java/com/resend/services/webhooks/WebhooksTest.java
@@ -35,15 +35,15 @@ public class WebhooksTest {
 
     private static final String GET_WEBHOOK_JSON =
             "{\"object\":\"webhook\",\"id\":\"" + WEBHOOK_ID + "\"," +
-            "\"created_at\":\"2023-08-22T15:28:00.000Z\",\"status\":\"enabled\"," +
+            "\"created_at\":\"2023-08-22 15:28:00+00\",\"status\":\"enabled\"," +
             "\"endpoint\":\"https://webhook.example.com/handler\"," +
             "\"events\":[\"email.sent\",\"email.received\"]," +
             "\"signing_secret\":\"whsec_xxxxxxxxxx\"}";
 
     private static final String LIST_WEBHOOKS_JSON =
             "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
-            "{\"id\":\"7ab123cd-ef45-6789-abcd-ef0123456789\",\"created_at\":\"2023-09-10T10:15:30.000Z\",\"status\":\"disabled\",\"endpoint\":\"https://first-webhook.example.com/handler\",\"events\":[\"email.delivered\",\"email.bounced\"]}," +
-            "{\"id\":\"" + WEBHOOK_ID + "\",\"created_at\":\"2023-08-22T15:28:00.000Z\",\"status\":\"enabled\",\"endpoint\":\"https://second-webhook.example.com/receive\",\"events\":[\"email.received\"]}" +
+            "{\"id\":\"7ab123cd-ef45-6789-abcd-ef0123456789\",\"created_at\":\"2023-09-10 10:15:30+00\",\"status\":\"disabled\",\"endpoint\":\"https://first-webhook.example.com/handler\",\"events\":[\"email.delivered\",\"email.bounced\"]}," +
+            "{\"id\":\"" + WEBHOOK_ID + "\",\"created_at\":\"2023-08-22 15:28:00+00\",\"status\":\"enabled\",\"endpoint\":\"https://second-webhook.example.com/receive\",\"events\":[\"email.received\"]}" +
             "]}";
 
     private static final String REMOVE_WEBHOOK_JSON =
@@ -140,7 +140,7 @@ public class WebhooksTest {
         ListParams params = ListParams.builder().limit(1).build();
         String paginatedJson =
                 "{\"object\":\"list\",\"has_more\":true,\"data\":[" +
-                "{\"id\":\"7ab123cd-ef45-6789-abcd-ef0123456789\",\"created_at\":\"2023-09-10T10:15:30.000Z\",\"status\":\"disabled\",\"endpoint\":\"https://first-webhook.example.com/handler\",\"events\":[\"email.delivered\"]}" +
+                "{\"id\":\"7ab123cd-ef45-6789-abcd-ef0123456789\",\"created_at\":\"2023-09-10 10:15:30+00\",\"status\":\"disabled\",\"endpoint\":\"https://first-webhook.example.com/handler\",\"events\":[\"email.delivered\"]}" +
                 "]}";
         AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, paginatedJson, true);
 


### PR DESCRIPTION
## Context for reviewers

The Resend API returns timestamps in Postgres text format: `YYYY-MM-DD HH:MM:SS[.ffffff]+00` (for example `2023-10-06 23:47:56.678+00`). It is not ISO 8601. Fractional seconds vary from zero to six digits, so no fixed width can be assumed.

Our docs, OpenAPI spec, and SDK test fixtures claimed ISO 8601 for a long time. We fixed the docs and the spec, and we are now updating every SDK so the fixtures show what the API really sends. The SDKs treat these values as opaque strings, so behavior does not change.

ISO 8601 remains correct in three places: `scheduled_at` as a request parameter, webhook event payloads (millisecond precision with `Z`), and `revoked_at` in the DELETE `/oauth/grants/{id}` response.

## What

Convert 143 fixture lines across 32 files. Each `*Util.java` expected object mirrors the mock JSON in the matching `*Test.java`, so both sides change together. `ContactImports`, `DomainClaims`, and the OAuth grant list fixtures already used the correct format.

## What stays ISO 8601 on purpose

- `scheduledAt` in request payloads and the javadoc on the request builders. The API accepts ISO there.
- The signed webhook payload strings in `WebhooksTest` (`verify()` tests). Webhooks emit ISO, and these exact bytes feed the HMAC signature.
- `revoked_at` in the revoke OAuth grant response. That endpoint returns ISO.

## Verification

- `./gradlew test`: all 22 test classes pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch test fixtures to the API’s Postgres text timestamp format (e.g., "2023-10-06 23:47:56.678+00") so mocked responses and expected objects match real API behavior. No runtime changes; timestamps remain plain strings.

- **Refactors**
  - Converted timestamps in test mocks and util fixtures to Postgres text format (supports 0–6 fractional digits).
  - Kept ISO 8601 only where the API uses it: scheduledAt request params, signed webhook payloads in verify tests, and revoked_at in the OAuth grant revoke response.
  - All tests pass (./gradlew test).

<sup>Written for commit 5fa8b8f99cafc30f906f169228207143435ad834. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-java/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

