### PR TITLE
feat: add broadcasts.cancel() method

### DIFF
--- a/src/main/java/com/resend/services/broadcasts/Broadcasts.java
+++ b/src/main/java/com/resend/services/broadcasts/Broadcasts.java
@@ -86,6 +86,17 @@ public class Broadcasts extends BaseService  {
         return resendMapper.readValue(responseBody, SendBroadcastResponseSuccess.class);
     }
 
+    public CancelBroadcastResponseSuccess cancel(String id) throws ResendException {
+        AbstractHttpResponse<String> response = httpClient.perform("/broadcasts/" + id + "/cancel", super.apiKey, HttpMethod.POST, "", MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+        return resendMapper.readValue(responseBody, CancelBroadcastResponseSuccess.class);
+    }
+
     /**
      * Deletes a broadcast based on the provided broadcast ID.
      *

--- a/src/main/java/com/resend/services/broadcasts/Broadcasts.java
+++ b/src/main/java/com/resend/services/broadcasts/Broadcasts.java
@@ -86,6 +86,13 @@ public class Broadcasts extends BaseService  {
         return resendMapper.readValue(responseBody, SendBroadcastResponseSuccess.class);
     }
 
+    /**
+     * Cancels a queued or scheduled broadcast.
+     *
+     * @param id The unique identifier of the broadcast to cancel.
+     * @return The CancelBroadcastResponseSuccess with the details of the canceled broadcast.
+     * @throws ResendException If an error occurs during the broadcast cancellation process.
+     */
     public CancelBroadcastResponseSuccess cancel(String id) throws ResendException {
         AbstractHttpResponse<String> response = httpClient.perform("/broadcasts/" + id + "/cancel", super.apiKey, HttpMethod.POST, "", MediaType.get("application/json"));
 

--- a/src/main/java/com/resend/services/broadcasts/model/CancelBroadcastResponseSuccess.java
+++ b/src/main/java/com/resend/services/broadcasts/model/CancelBroadcastResponseSuccess.java
@@ -2,19 +2,37 @@ package com.resend.services.broadcasts.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Represents the response for a successful broadcast cancellation.
+ * Extends the BaseBroadcastResponse class.
+ */
 public class CancelBroadcastResponseSuccess extends BaseBroadcastResponse {
     @JsonProperty("object")
     private String object;
 
+    /**
+     * Default constructor
+     */
     public CancelBroadcastResponseSuccess() {
 
     }
 
+    /**
+     * Constructs a successful response for cancelling a broadcast.
+     *
+     * @param id        The ID of the broadcast.
+     * @param object    The object of the broadcast.
+     */
     public CancelBroadcastResponseSuccess(String id, String object) {
         super(id);
         this.object = object;
     }
 
+    /**
+     * Get the object.
+     *
+     * @return The type of the data.
+     */
     public String getObject() {
         return object;
     }

--- a/src/main/java/com/resend/services/broadcasts/model/CancelBroadcastResponseSuccess.java
+++ b/src/main/java/com/resend/services/broadcasts/model/CancelBroadcastResponseSuccess.java
@@ -1,0 +1,21 @@
+package com.resend.services.broadcasts.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CancelBroadcastResponseSuccess extends BaseBroadcastResponse {
+    @JsonProperty("object")
+    private String object;
+
+    public CancelBroadcastResponseSuccess() {
+
+    }
+
+    public CancelBroadcastResponseSuccess(String id, String object) {
+        super(id);
+        this.object = object;
+    }
+
+    public String getObject() {
+        return object;
+    }
+}

--- a/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
+++ b/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
@@ -42,6 +42,9 @@ public class BroadcastsTest {
     private static final String REMOVE_RESPONSE_JSON =
             "{\"id\":\"" + GET_BROADCAST_ID + "\",\"object\":\"object\",\"deleted\":true}";
 
+    private static final String CANCEL_RESPONSE_JSON =
+            "{\"id\":\"" + GET_BROADCAST_ID + "\",\"object\":\"broadcast\"}";
+
     private static final String LIST_RESPONSE_JSON =
             "{\"object\":\"list\",\"has_more\":true,\"data\":[" +
             "{\"id\":\"1\",\"audience_id\":\"" + AUDIENCE_ID + "\",\"status\":\"draft\",\"created_at\":\"2024-12-01 19:32:22.98+00\"}," +
@@ -134,6 +137,20 @@ public class BroadcastsTest {
         assertNotNull(response);
         assertEquals(GET_BROADCAST_ID, response.getId());
         assertTrue(response.isDeleted());
+    }
+
+    @Test
+    public void testCancelBroadcast_Success() throws ResendException {
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, CANCEL_RESPONSE_JSON, true);
+
+        when(httpClient.perform(eq("/broadcasts/" + GET_BROADCAST_ID + "/cancel"), anyString(), eq(HttpMethod.POST), eq(""), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        CancelBroadcastResponseSuccess response = broadcasts.cancel(GET_BROADCAST_ID);
+
+        assertNotNull(response);
+        assertEquals(GET_BROADCAST_ID, response.getId());
+        assertEquals("broadcast", response.getObject());
     }
 
     @Test

--- a/src/test/java/com/resend/services/util/BroadcastsUtil.java
+++ b/src/test/java/com/resend/services/util/BroadcastsUtil.java
@@ -70,10 +70,6 @@ public class BroadcastsUtil {
         return new RemoveBroadcastResponseSuccess("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", "object",true);
     }
 
-    public static CancelBroadcastResponseSuccess cancelBroadcastResponseSuccess() {
-        return new CancelBroadcastResponseSuccess("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", "broadcast");
-    }
-
     public static ListBroadcastsResponseSuccess createBroadcastsListResponse() {
         List<Broadcast> broadcastList = new ArrayList<>();
 

--- a/src/test/java/com/resend/services/util/BroadcastsUtil.java
+++ b/src/test/java/com/resend/services/util/BroadcastsUtil.java
@@ -70,6 +70,10 @@ public class BroadcastsUtil {
         return new RemoveBroadcastResponseSuccess("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", "object",true);
     }
 
+    public static CancelBroadcastResponseSuccess cancelBroadcastResponseSuccess() {
+        return new CancelBroadcastResponseSuccess("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", "broadcast");
+    }
+
     public static ListBroadcastsResponseSuccess createBroadcastsListResponse() {
         List<Broadcast> broadcastList = new ArrayList<>();
 


### PR DESCRIPTION
## Summary
- Adds `Broadcasts.cancel(id)`, calling `POST /broadcasts/:id/cancel` to cancel a queued or scheduled broadcast.
- Mirrors `Emails.cancel()`'s request shape (empty-string body, same content type).
- Adds `CancelBroadcastResponseSuccess` model (id + object).

Part of the broadcast cancel rollout: resend/resend-monorepo#8126, resend/resend-openapi#85, resend/resend-node#1059, resend/resend-docs#1722, resend/resend-go#144.

## Test plan
- [x] Added `testCancelBroadcast_Success` following the existing mock-`IHttpClient` pattern used by `testDeleteBroadcast_Success`
- [ ] Could not run `./gradlew test` locally (no JDK available in this environment) — relying on CI to verify compilation and test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Broadcasts.cancel(id)` to cancel queued or scheduled broadcasts via POST `/broadcasts/:id/cancel` with an empty JSON body, mirroring `Emails.cancel()`.

- **New Features**
  - Added `CancelBroadcastResponseSuccess` (`id`, `object`) and `testCancelBroadcast_Success`.
  - Added JavaDoc for `cancel()` and `CancelBroadcastResponseSuccess`; removed an unused test helper.

<sup>Written for commit 38ddedbf38cd83493c696b3870c27ae5dee29358. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-java/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

