### PR TITLE
feat(automations): duplicate endpoint

### DIFF
--- a/src/main/java/com/resend/services/automations/Automations.java
+++ b/src/main/java/com/resend/services/automations/Automations.java
@@ -138,6 +138,24 @@ public class Automations extends BaseService {
     }
 
     /**
+     * Duplicates an automation by its unique identifier.
+     *
+     * @param automationId The unique identifier of the automation.
+     * @return The response containing the newly created automation ID.
+     * @throws ResendException If an error occurs while duplicating the automation.
+     */
+    public DuplicateAutomationResponseSuccess duplicate(String automationId) throws ResendException {
+        AbstractHttpResponse<String> response = httpClient.perform("/automations/" + automationId + "/duplicate", super.apiKey, HttpMethod.POST, "", MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+        return resendMapper.readValue(responseBody, DuplicateAutomationResponseSuccess.class);
+    }
+
+    /**
      * Stops an automation by its unique identifier.
      *
      * @param automationId The unique identifier of the automation.

--- a/src/main/java/com/resend/services/automations/model/DuplicateAutomationResponseSuccess.java
+++ b/src/main/java/com/resend/services/automations/model/DuplicateAutomationResponseSuccess.java
@@ -1,0 +1,50 @@
+package com.resend.services.automations.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a successful response from duplicating an automation.
+ */
+public class DuplicateAutomationResponseSuccess {
+
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("id")
+    private String id;
+
+    /**
+     * Default constructor for deserialization.
+     */
+    public DuplicateAutomationResponseSuccess() {
+    }
+
+    /**
+     * Constructs a DuplicateAutomationResponseSuccess with specified values.
+     *
+     * @param object The object type.
+     * @param id The ID of the newly created automation.
+     */
+    public DuplicateAutomationResponseSuccess(String object, String id) {
+        this.object = object;
+        this.id = id;
+    }
+
+    /**
+     * Retrieves the object type.
+     *
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Retrieves the ID of the newly created automation.
+     *
+     * @return The automation ID.
+     */
+    public String getId() {
+        return id;
+    }
+}

--- a/src/test/java/com/resend/services/automations/AutomationsTest.java
+++ b/src/test/java/com/resend/services/automations/AutomationsTest.java
@@ -43,6 +43,9 @@ public class AutomationsTest {
     private static final String DELETE_AUTOMATION_JSON =
             "{\"object\":\"automation\",\"id\":\"" + AUTOMATION_ID + "\",\"deleted\":true}";
 
+    private static final String DUPLICATE_AUTOMATION_JSON =
+            "{\"object\":\"automation\",\"id\":\"e169aa45-1ecf-4183-9955-b1499d5701d3\"}";
+
     private static final String STOP_AUTOMATION_JSON =
             "{\"object\":\"automation\",\"id\":\"" + AUTOMATION_ID + "\",\"status\":\"disabled\"}";
 
@@ -170,6 +173,20 @@ public class AutomationsTest {
         assertNotNull(response);
         assertTrue(response.getDeleted());
         assertEquals(AUTOMATION_ID, response.getId());
+    }
+
+    @Test
+    public void testDuplicateAutomation_Success() throws ResendException {
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, DUPLICATE_AUTOMATION_JSON, true);
+
+        when(httpClient.perform(eq("/automations/" + AUTOMATION_ID + "/duplicate"), anyString(), eq(HttpMethod.POST), eq(""), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        DuplicateAutomationResponseSuccess response = automations.duplicate(AUTOMATION_ID);
+
+        assertNotNull(response);
+        assertEquals("automation", response.getObject());
+        assertEquals("e169aa45-1ecf-4183-9955-b1499d5701d3", response.getId());
     }
 
     @Test


### PR DESCRIPTION
Adds `automations.duplicate(automationId)` for `POST /automations/{id}/duplicate`, returning `DuplicateAutomationResponseSuccess`.

Resolves DEV-1711. Mirrors the existing `stop` pattern and resend-node https://github.com/resend/resend-node/pull/1071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `automations.duplicate(automationId)` to expose `POST /automations/{id}/duplicate` in the Java SDK, letting clients duplicate an automation and receive the new automation ID. This addresses DEV-1711 and mirrors the existing `stop` pattern.

- Calls `/automations/{id}/duplicate` and deserializes into `DuplicateAutomationResponseSuccess` (`object`, `id`).
- Throws `ResendException` on non-2xx responses, consistent with other automation methods.
- Introduces `DuplicateAutomationResponseSuccess` and a unit test; no breaking changes and no migration required.

<sup>Written for commit 027a6019eb382828c1a43b93700026de18be0857. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-java/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

