### PR TITLE
fix(contacts): properties response shape

### DIFF
--- a/src/main/java/com/resend/services/contacts/model/ContactPropertyValue.java
+++ b/src/main/java/com/resend/services/contacts/model/ContactPropertyValue.java
@@ -1,0 +1,52 @@
+package com.resend.services.contacts.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a custom property value on a contact, returned as an object
+ * with the value and its type.
+ */
+public class ContactPropertyValue {
+
+    @JsonProperty("value")
+    private Object value;
+
+    @JsonProperty("type")
+    private String type;
+
+    /**
+     * Default constructor
+     */
+    public ContactPropertyValue() {
+
+    }
+
+    /**
+     * Creates an instance of ContactPropertyValue with the specified attributes.
+     *
+     * @param value The property value, a String, Number, or Boolean depending on type.
+     * @param type  The property type ("string", "number", or "boolean").
+     */
+    public ContactPropertyValue(final Object value, final String type) {
+        this.value = value;
+        this.type = type;
+    }
+
+    /**
+     * Gets the property value.
+     *
+     * @return The property value, a String, Number, or Boolean depending on type.
+     */
+    public Object getValue() {
+        return value;
+    }
+
+    /**
+     * Gets the property type.
+     *
+     * @return The property type ("string", "number", or "boolean").
+     */
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/resend/services/contacts/model/GetContactResponseSuccess.java
+++ b/src/main/java/com/resend/services/contacts/model/GetContactResponseSuccess.java
@@ -2,6 +2,8 @@ package com.resend.services.contacts.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 /**
  * Represents a successful response for getting a contact.
  * Extends the Contact class.
@@ -10,6 +12,9 @@ public class GetContactResponseSuccess extends Contact {
 
     @JsonProperty("object")
     private String object;
+
+    @JsonProperty("properties")
+    private Map<String, ContactPropertyValue> properties;
 
     /**
      * Default constructor
@@ -41,5 +46,14 @@ public class GetContactResponseSuccess extends Contact {
      */
     public String getObject() {
         return object;
+    }
+
+    /**
+     * Gets the custom properties of the contact. Only available for global contacts.
+     *
+     * @return The custom properties of the contact.
+     */
+    public Map<String, ContactPropertyValue> getProperties() {
+        return properties;
     }
 }

--- a/src/test/java/com/resend/services/contacts/ContactsTest.java
+++ b/src/test/java/com/resend/services/contacts/ContactsTest.java
@@ -26,7 +26,8 @@ public class ContactsTest {
     private static final String GET_CONTACT_JSON =
             "{\"object\":\"contacts\",\"id\":\"123\",\"email\":\"user@example.com\"," +
             "\"first_name\":\"test\",\"last_name\":\"test\"," +
-            "\"created_at\":\"2025-04-30 12:00:00+00\",\"unsubscribed\":false}";
+            "\"created_at\":\"2025-04-30 12:00:00+00\",\"unsubscribed\":false," +
+            "\"properties\":{\"tier\":{\"value\":\"premium\",\"type\":\"string\"}}}";
     private static final String LIST_CONTACTS_JSON =
             "{\"data\":[" +
             "{\"id\":\"1\",\"email\":\"frodo.baggins@shire.com\",\"first_name\":\"Frodo\"," +
@@ -229,6 +230,8 @@ public class ContactsTest {
         assertNotNull(res);
         assertEquals("123", res.getId());
         assertEquals("user@example.com", res.getEmail());
+        assertEquals("premium", res.getProperties().get("tier").getValue());
+        assertEquals("string", res.getProperties().get("tier").getType());
     }
 
     @Test


### PR DESCRIPTION
`GET /contacts/:id` returns `properties` where each entry is a `{value, type}` object, but the model had no `properties` field at all — Jackson silently dropped it. Adds a `ContactPropertyValue` model (`value`: String, Number, or Boolean; `type`) and a `properties` map on `GetContactResponseSuccess` (retrieve only — the list response doesn't return properties). Create/update request params stay flat maps.

Matches resend-node's `get-contact.interface.ts` and resend-rust's `ContactPropertyResponse`.

docs: https://resend.com/docs/api-reference/contacts/get-contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deserialization of contact properties in `GET /contacts/:id`. Previously the SDK dropped the `properties` field; now it exposes a `properties` map with typed values so consumers can read custom fields.

- Adds `ContactPropertyValue` with `value` (String/Number/Boolean) and `type`.
- Adds `properties: Map<String, ContactPropertyValue>` to `GetContactResponseSuccess`. Only retrieve responses include properties; list responses remain unchanged.
- Create/update request params remain flat maps. No migration required.
- Aligns response shape with the public API docs and other SDKs.

<sup>Written for commit 1b63a02051ffa1353f63ec3f00d6586529194f99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-java/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

