### PR TITLE
feat(api-keys): add update endpoint

### DIFF
--- a/src/main/java/com/resend/services/apikeys/ApiKeys.java
+++ b/src/main/java/com/resend/services/apikeys/ApiKeys.java
@@ -10,6 +10,8 @@ import com.resend.core.service.BaseService;
 import com.resend.services.apikeys.model.CreateApiKeyResponse;
 import com.resend.services.apikeys.model.CreateApiKeyOptions;
 import com.resend.services.apikeys.model.ListApiKeysResponse;
+import com.resend.services.apikeys.model.UpdateApiKeyOptions;
+import com.resend.services.apikeys.model.UpdateApiKeyResponseSuccess;
 import okhttp3.MediaType;
 
 /**
@@ -89,6 +91,26 @@ public final class ApiKeys extends BaseService {
 
         ListApiKeysResponse listApiKeysResponse = resendMapper.readValue(responseBody, ListApiKeysResponse.class);
         return listApiKeysResponse;
+    }
+
+    /**
+     * Updates an api key by its unique identifier.
+     *
+     * @param apiKeyId The unique identifier of the api key to update.
+     * @param updateApiKeyOptions The new data for the api key.
+     * @return The response indicating the status of the api key update.
+     * @throws ResendException If an error occurs during the api key update process.
+     */
+    public UpdateApiKeyResponseSuccess update(String apiKeyId, UpdateApiKeyOptions updateApiKeyOptions) throws ResendException {
+        String payload = super.resendMapper.writeValue(updateApiKeyOptions);
+        AbstractHttpResponse<String> response = httpClient.perform("/api-keys/" + apiKeyId, super.apiKey, HttpMethod.PATCH, payload, MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+        return resendMapper.readValue(responseBody, UpdateApiKeyResponseSuccess.class);
     }
 
     /**

--- a/src/main/java/com/resend/services/apikeys/model/UpdateApiKeyOptions.java
+++ b/src/main/java/com/resend/services/apikeys/model/UpdateApiKeyOptions.java
@@ -1,0 +1,72 @@
+package com.resend.services.apikeys.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a request to update an api key.
+ */
+public class UpdateApiKeyOptions {
+
+    @JsonProperty("name")
+    private final String name;
+
+    /**
+     * Constructs an UpdateApiKeyOptions object using the provided builder.
+     *
+     * @param builder The builder to construct the UpdateApiKeyOptions.
+     */
+    private UpdateApiKeyOptions(Builder builder) {
+        this.name = builder.name;
+    }
+
+    /**
+     * Get the name of the API Key.
+     *
+     * @return The name of the API Key.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Create a new builder instance for constructing UpdateApiKeyOptions objects.
+     *
+     * @return A new builder instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing UpdateApiKeyOptions objects.
+     */
+    public static class Builder {
+        /**
+         * Creates a new Builder instance.
+         */
+        public Builder() {
+        }
+
+        private String name;
+
+        /**
+         * Set the name of the Api Key.
+         *
+         * @param name The name of the Api Key.
+         * @return The builder instance.
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Build a new UpdateApiKeyOptions object.
+         *
+         * @return A new UpdateApiKeyOptions object.
+         */
+        public UpdateApiKeyOptions build() {
+            return new UpdateApiKeyOptions(this);
+        }
+    }
+}

--- a/src/main/java/com/resend/services/apikeys/model/UpdateApiKeyResponseSuccess.java
+++ b/src/main/java/com/resend/services/apikeys/model/UpdateApiKeyResponseSuccess.java
@@ -1,0 +1,50 @@
+package com.resend.services.apikeys.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a successful response for updating an api key.
+ */
+public class UpdateApiKeyResponseSuccess {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("object")
+    private String object;
+
+    /**
+     * Default constructor
+     */
+    public UpdateApiKeyResponseSuccess() {
+    }
+
+    /**
+     * Constructs a successful response for updating an UpdateApiKeyResponseSuccess object.
+     *
+     * @param id     The ID of the api key.
+     * @param object The object of the api key.
+     */
+    public UpdateApiKeyResponseSuccess(final String id, final String object) {
+        this.id = id;
+        this.object = object;
+    }
+
+    /**
+     * Gets the ID of the api key.
+     *
+     * @return The ID of the api key.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the object of the api key.
+     *
+     * @return The object of the api key.
+     */
+    public String getObject() {
+        return object;
+    }
+}

--- a/src/test/java/com/resend/services/apikeys/ApiKeysTest.java
+++ b/src/test/java/com/resend/services/apikeys/ApiKeysTest.java
@@ -7,6 +7,8 @@ import com.resend.core.net.IHttpClient;
 import com.resend.services.apikeys.model.CreateApiKeyOptions;
 import com.resend.services.apikeys.model.CreateApiKeyResponse;
 import com.resend.services.apikeys.model.ListApiKeysResponse;
+import com.resend.services.apikeys.model.UpdateApiKeyOptions;
+import com.resend.services.apikeys.model.UpdateApiKeyResponseSuccess;
 import com.resend.services.util.ApiKeysUtil;
 import okhttp3.MediaType;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +24,8 @@ import static org.mockito.Mockito.when;
 public class ApiKeysTest {
 
     private static final String CREATE_RESPONSE_JSON = "{\"id\":\"123\",\"token\":\"re_123\"}";
+
+    private static final String UPDATE_RESPONSE_JSON = "{\"id\":\"123\",\"object\":\"api_key\"}";
 
     private static final String LIST_RESPONSE_JSON = "{\"data\":[" +
             "{\"id\":\"abcdefg-4321-5678-ijklmnop\",\"name\":\"Production\"," +
@@ -67,6 +71,34 @@ public class ApiKeysTest {
 
         ResendException ex = assertThrows(ResendException.class, () -> apiKeys.create(request));
         assertEquals(422, (int) ex.getStatusCode());
+    }
+
+    @Test
+    public void testUpdateApiKey_Success() throws ResendException {
+        UpdateApiKeyOptions request = ApiKeysUtil.updateApiKeyOptions();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, UPDATE_RESPONSE_JSON, true);
+
+        when(httpClient.perform(eq("/api-keys/123"), anyString(), eq(HttpMethod.PATCH), anyString(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        UpdateApiKeyResponseSuccess response = apiKeys.update("123", request);
+
+        assertNotNull(response);
+        assertEquals("123", response.getId());
+        assertEquals("api_key", response.getObject());
+    }
+
+    @Test
+    public void testUpdateApiKey_ApiError_ThrowsResendException() throws ResendException {
+        UpdateApiKeyOptions request = ApiKeysUtil.updateApiKeyOptions();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(404,
+                "{\"name\":\"not_found\",\"message\":\"API key not found\"}", false);
+
+        when(httpClient.perform(eq("/api-keys/123"), anyString(), eq(HttpMethod.PATCH), anyString(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        ResendException ex = assertThrows(ResendException.class, () -> apiKeys.update("123", request));
+        assertEquals(404, (int) ex.getStatusCode());
     }
 
     @Test

--- a/src/test/java/com/resend/services/util/ApiKeysUtil.java
+++ b/src/test/java/com/resend/services/util/ApiKeysUtil.java
@@ -4,6 +4,8 @@ import com.resend.services.apikeys.model.ApiKey;
 import com.resend.services.apikeys.model.CreateApiKeyOptions;
 import com.resend.services.apikeys.model.CreateApiKeyResponse;
 import com.resend.services.apikeys.model.ListApiKeysResponse;
+import com.resend.services.apikeys.model.UpdateApiKeyOptions;
+import com.resend.services.apikeys.model.UpdateApiKeyResponseSuccess;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,6 +45,16 @@ public class ApiKeysUtil {
         ListApiKeysResponse response = new ListApiKeysResponse(apiKeys, true, "list");
 
         return response;
+    }
+
+    public static final UpdateApiKeyOptions updateApiKeyOptions() {
+        return UpdateApiKeyOptions.builder()
+                .name("prod-renamed")
+                .build();
+    }
+
+    public static final UpdateApiKeyResponseSuccess updateApiKeyResponse() {
+        return new UpdateApiKeyResponseSuccess("123", "api_key");
     }
 
 }


### PR DESCRIPTION
## Summary
- Adds `ApiKeys.update(apiKeyId, UpdateApiKeyOptions)` for the new `PATCH /api-keys/:id` endpoint — see https://resend.com/docs/api-reference/api-keys/update-api-key.
- Only `name` is patchable. `permission`/`domain_id` are deliberately not exposed — the endpoint doesn't accept them (prevents a leaked management key from silently widening another key's scope).

Draft — SDK rollout in progress, tracked in Linear as DEV-1219.

## Test plan
- [x] `./gradlew build` — BUILD SUCCESSFUL, all tests pass