### PR TITLE
feat(broadcasts): add recipients method to list broadcast recipients

### DIFF
--- a/src/main/java/com/resend/services/broadcasts/Broadcasts.java
+++ b/src/main/java/com/resend/services/broadcasts/Broadcasts.java
@@ -162,6 +162,28 @@ public class Broadcasts extends BaseService  {
     }
 
     /**
+     * Retrieves the recipients of a broadcast for a given event type, such as who opened,
+     * clicked, or bounced.
+     *
+     * @param id The unique identifier of the broadcast.
+     * @param params The params used to filter and paginate the recipients.
+     * @return A ListBroadcastRecipientsResponseSuccess containing the paginated list of recipients.
+     * @throws ResendException If an error occurs during the broadcast recipients retrieval process.
+     */
+    public ListBroadcastRecipientsResponseSuccess recipients(String id, ListBroadcastRecipientsParams params) throws ResendException {
+        String pathWithQuery = "/broadcasts/" + id + "/recipients" + params.toQueryString();
+        AbstractHttpResponse<String> response = this.httpClient.perform(pathWithQuery, super.apiKey, HttpMethod.GET, null, MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        return resendMapper.readValue(responseBody, ListBroadcastRecipientsResponseSuccess.class);
+    }
+
+    /**
      * Updates a Broadcast.
      *
      * @param updateBroadcastOptions The Broadcast details.

--- a/src/main/java/com/resend/services/broadcasts/model/BroadcastRecipient.java
+++ b/src/main/java/com/resend/services/broadcasts/model/BroadcastRecipient.java
@@ -1,0 +1,113 @@
+package com.resend.services.broadcasts.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents a single recipient row for a broadcast, scoped to the requested event type.
+ */
+public class BroadcastRecipient {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("contact_id")
+    private String contactId;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("count")
+    private Integer count;
+
+    @JsonProperty("bounce_type")
+    private String bounceType;
+
+    @JsonProperty("clicked_links")
+    private List<BroadcastRecipientClickedLink> clickedLinks;
+
+    /**
+     * Default constructor
+     */
+    public BroadcastRecipient() {
+
+    }
+
+    /**
+     * Constructs a new BroadcastRecipient instance.
+     *
+     * @param id Opaque cursor identifying this row, used for pagination.
+     * @param contactId The ID of the contact associated with this recipient, if one exists.
+     * @param email The recipient's email address.
+     * @param count The number of times this recipient triggered the event. Only present when
+     *              {@code type} is {@code opened} or {@code clicked}.
+     * @param bounceType The type of bounce. Only present when {@code type} is {@code bounced}.
+     * @param clickedLinks The links this recipient clicked. Only present when {@code type} is
+     *                     {@code clicked}.
+     */
+    public BroadcastRecipient(String id, String contactId, String email, Integer count,
+                               String bounceType, List<BroadcastRecipientClickedLink> clickedLinks) {
+        this.id = id;
+        this.contactId = contactId;
+        this.email = email;
+        this.count = count;
+        this.bounceType = bounceType;
+        this.clickedLinks = clickedLinks;
+    }
+
+    /**
+     * Gets the opaque cursor identifying this row, used for pagination.
+     *
+     * @return the row cursor
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the ID of the contact associated with this recipient, if one exists.
+     *
+     * @return the contact ID, or null if none
+     */
+    public String getContactId() {
+        return contactId;
+    }
+
+    /**
+     * Gets the recipient's email address.
+     *
+     * @return the recipient email
+     */
+    public String getEmail() {
+        return email;
+    }
+
+    /**
+     * Gets the number of times this recipient triggered the event.
+     * Only present when {@code type} is {@code opened} or {@code clicked}.
+     *
+     * @return the event count, or null if not applicable
+     */
+    public Integer getCount() {
+        return count;
+    }
+
+    /**
+     * Gets the type of bounce. Only present when {@code type} is {@code bounced}.
+     *
+     * @return the bounce type, or null if not applicable
+     */
+    public String getBounceType() {
+        return bounceType;
+    }
+
+    /**
+     * Gets the links this recipient clicked. Only present when {@code type} is {@code clicked}.
+     *
+     * @return the clicked links, or null if not applicable
+     */
+    public List<BroadcastRecipientClickedLink> getClickedLinks() {
+        return clickedLinks;
+    }
+}

--- a/src/main/java/com/resend/services/broadcasts/model/BroadcastRecipientBounceType.java
+++ b/src/main/java/com/resend/services/broadcasts/model/BroadcastRecipientBounceType.java
@@ -1,0 +1,50 @@
+package com.resend.services.broadcasts.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents the bounce type used to filter a broadcast's bounced recipients.
+ * Only meaningful when the {@link BroadcastRecipientEventType} filter is {@code bounced}.
+ */
+public enum BroadcastRecipientBounceType {
+    /** The recipient's email address is permanently invalid. */
+    PERMANENT("permanent"),
+    /** The bounce was temporary, e.g. a full mailbox or a temporary server issue. */
+    TRANSIENT("transient"),
+    /** The bounce reason could not be determined. */
+    UNDETERMINED("undetermined");
+
+    private final String value;
+
+    BroadcastRecipientBounceType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the string value of the bounce type.
+     *
+     * @return The bounce type value.
+     */
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Creates a BroadcastRecipientBounceType from a string value.
+     *
+     * @param value The string value.
+     * @return The corresponding BroadcastRecipientBounceType.
+     * @throws IllegalArgumentException If the value is unknown.
+     */
+    @JsonCreator
+    public static BroadcastRecipientBounceType fromValue(String value) {
+        for (BroadcastRecipientBounceType bounceType : BroadcastRecipientBounceType.values()) {
+            if (bounceType.value.equals(value)) {
+                return bounceType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown bounce type: " + value);
+    }
+}

--- a/src/main/java/com/resend/services/broadcasts/model/BroadcastRecipientClickedLink.java
+++ b/src/main/java/com/resend/services/broadcasts/model/BroadcastRecipientClickedLink.java
@@ -1,0 +1,51 @@
+package com.resend.services.broadcasts.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a link clicked by a broadcast recipient.
+ */
+public class BroadcastRecipientClickedLink {
+
+    @JsonProperty("url")
+    private String url;
+
+    @JsonProperty("clicks")
+    private Integer clicks;
+
+    /**
+     * Default constructor
+     */
+    public BroadcastRecipientClickedLink() {
+
+    }
+
+    /**
+     * Constructs a new BroadcastRecipientClickedLink instance.
+     *
+     * @param url The clicked URL.
+     * @param clicks The number of times this recipient clicked this URL.
+     */
+    public BroadcastRecipientClickedLink(String url, Integer clicks) {
+        this.url = url;
+        this.clicks = clicks;
+    }
+
+    /**
+     * Gets the clicked URL.
+     *
+     * @return the clicked URL
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * Gets the number of times this recipient clicked this URL.
+     *
+     * @return the number of clicks
+     */
+    public Integer getClicks() {
+        return clicks;
+    }
+}

--- a/src/main/java/com/resend/services/broadcasts/model/BroadcastRecipientEventType.java
+++ b/src/main/java/com/resend/services/broadcasts/model/BroadcastRecipientEventType.java
@@ -1,0 +1,59 @@
+package com.resend.services.broadcasts.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents the event type used to filter a broadcast's recipients.
+ */
+public enum BroadcastRecipientEventType {
+    /** Recipients the broadcast was sent to. */
+    SENT("sent"),
+    /** Recipients whose email was delivered. */
+    DELIVERED("delivered"),
+    /** Recipients who opened the email. */
+    OPENED("opened"),
+    /** Recipients who clicked a link in the email. */
+    CLICKED("clicked"),
+    /** Recipients whose email bounced. */
+    BOUNCED("bounced"),
+    /** Recipients who marked the email as spam. */
+    COMPLAINED("complained"),
+    /** Recipients who unsubscribed. */
+    UNSUBSCRIBED("unsubscribed"),
+    /** Recipients who were suppressed and not sent the email. */
+    SUPPRESSED("suppressed");
+
+    private final String value;
+
+    BroadcastRecipientEventType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the string value of the event type.
+     *
+     * @return The event type value.
+     */
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Creates a BroadcastRecipientEventType from a string value.
+     *
+     * @param value The string value.
+     * @return The corresponding BroadcastRecipientEventType.
+     * @throws IllegalArgumentException If the value is unknown.
+     */
+    @JsonCreator
+    public static BroadcastRecipientEventType fromValue(String value) {
+        for (BroadcastRecipientEventType type : BroadcastRecipientEventType.values()) {
+            if (type.value.equals(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown type: " + value);
+    }
+}

--- a/src/main/java/com/resend/services/broadcasts/model/ListBroadcastRecipientsParams.java
+++ b/src/main/java/com/resend/services/broadcasts/model/ListBroadcastRecipientsParams.java
@@ -226,6 +226,9 @@ public class ListBroadcastRecipientsParams {
             if (hasAfter && hasBefore) {
                 throw new IllegalArgumentException("after and before cannot be used together");
             }
+            if (bounceType != null && type != BroadcastRecipientEventType.BOUNCED) {
+                throw new IllegalArgumentException("bounceType can only be used when type is BOUNCED");
+            }
             return new ListBroadcastRecipientsParams(this);
         }
     }

--- a/src/main/java/com/resend/services/broadcasts/model/ListBroadcastRecipientsParams.java
+++ b/src/main/java/com/resend/services/broadcasts/model/ListBroadcastRecipientsParams.java
@@ -1,0 +1,232 @@
+package com.resend.services.broadcasts.model;
+
+import com.resend.core.helper.URLHelper;
+import com.resend.core.net.ListParams;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Represents the query parameters for listing a broadcast's recipients.
+ *
+ * <p>Supports pagination ({@code limit}, {@code after}, {@code before}), a required
+ * {@code type} filter, an optional {@code email} substring filter, and an optional
+ * {@code bounceType} filter (only meaningful when {@code type} is {@code bounced}).</p>
+ */
+public class ListBroadcastRecipientsParams {
+
+    private final BroadcastRecipientEventType type;
+
+    private final String email;
+
+    private final BroadcastRecipientBounceType bounceType;
+
+    private final Integer limit;
+
+    private final String after;
+
+    private final String before;
+
+    /**
+     * Constructs a ListBroadcastRecipientsParams object using the provided builder.
+     *
+     * @param builder The builder to construct the params.
+     */
+    public ListBroadcastRecipientsParams(Builder builder) {
+        this.type = builder.type;
+        this.email = builder.email;
+        this.bounceType = builder.bounceType;
+        this.limit = builder.limit;
+        this.after = builder.after;
+        this.before = builder.before;
+    }
+
+    /**
+     * Gets the event type filter.
+     *
+     * @return The recipient event type.
+     */
+    public BroadcastRecipientEventType getType() {
+        return type;
+    }
+
+    /**
+     * Gets the email substring filter.
+     *
+     * @return The email filter.
+     */
+    public String getEmail() {
+        return email;
+    }
+
+    /**
+     * Gets the bounce type filter.
+     *
+     * @return The bounce type filter.
+     */
+    public BroadcastRecipientBounceType getBounceType() {
+        return bounceType;
+    }
+
+    /**
+     * Gets the pagination limit.
+     *
+     * @return The pagination limit.
+     */
+    public Integer getLimit() {
+        return limit;
+    }
+
+    /**
+     * Gets the cursor for pagination (after).
+     *
+     * @return The after cursor.
+     */
+    public String getAfter() {
+        return after;
+    }
+
+    /**
+     * Gets the cursor for pagination (before).
+     *
+     * @return The before cursor.
+     */
+    public String getBefore() {
+        return before;
+    }
+
+    /**
+     * Converts the parameters to a query string.
+     *
+     * @return A query string starting with "?" if parameters exist, or an empty string otherwise.
+     */
+    public String toQueryString() {
+        ListParams base = ListParams.builder()
+                .limit(limit)
+                .after(after)
+                .before(before)
+                .build();
+
+        Map<String, String> extras = new LinkedHashMap<>();
+        extras.put("type", type.getValue());
+        extras.put("email", email);
+        extras.put("bounce_type", bounceType != null ? bounceType.getValue() : null);
+
+        return URLHelper.parse(base, extras);
+    }
+
+    /**
+     * Creates a new builder instance for constructing ListBroadcastRecipientsParams objects.
+     *
+     * @return A new builder instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing ListBroadcastRecipientsParams objects.
+     */
+    public static class Builder {
+        /**
+         * Creates a new Builder instance.
+         */
+        public Builder() {
+        }
+
+        private BroadcastRecipientEventType type;
+        private String email;
+        private BroadcastRecipientBounceType bounceType;
+        private Integer limit;
+        private String after;
+        private String before;
+
+        /**
+         * Sets the event type to filter recipients by.
+         *
+         * @param type The recipient event type.
+         * @return The builder instance.
+         */
+        public Builder type(BroadcastRecipientEventType type) {
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * Filters recipients by a substring of their email address.
+         *
+         * @param email The email substring filter.
+         * @return The builder instance.
+         */
+        public Builder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        /**
+         * Filters bounced recipients by bounce type. Only meaningful when {@code type} is
+         * {@link BroadcastRecipientEventType#BOUNCED}.
+         *
+         * @param bounceType The bounce type filter.
+         * @return The builder instance.
+         */
+        public Builder bounceType(BroadcastRecipientBounceType bounceType) {
+            this.bounceType = bounceType;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of recipients to return (1-100, default 20).
+         *
+         * @param limit The pagination limit.
+         * @return The builder instance.
+         */
+        public Builder limit(Integer limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        /**
+         * Sets the cursor for fetching recipients after this cursor. Cannot be used with
+         * {@link #before(String)}.
+         *
+         * @param after The after cursor.
+         * @return The builder instance.
+         */
+        public Builder after(String after) {
+            this.after = after;
+            return this;
+        }
+
+        /**
+         * Sets the cursor for fetching recipients before this cursor. Cannot be used with
+         * {@link #after(String)}.
+         *
+         * @param before The before cursor.
+         * @return The builder instance.
+         */
+        public Builder before(String before) {
+            this.before = before;
+            return this;
+        }
+
+        /**
+         * Builds a new ListBroadcastRecipientsParams instance.
+         *
+         * @return A new ListBroadcastRecipientsParams instance.
+         * @throws IllegalArgumentException if {@code type} is not set, or if both {@code after}
+         *         and {@code before} are set.
+         */
+        public ListBroadcastRecipientsParams build() {
+            if (type == null) {
+                throw new IllegalArgumentException("type must be provided.");
+            }
+            boolean hasAfter = after != null && !after.isEmpty();
+            boolean hasBefore = before != null && !before.isEmpty();
+            if (hasAfter && hasBefore) {
+                throw new IllegalArgumentException("after and before cannot be used together");
+            }
+            return new ListBroadcastRecipientsParams(this);
+        }
+    }
+}

--- a/src/main/java/com/resend/services/broadcasts/model/ListBroadcastRecipientsParams.java
+++ b/src/main/java/com/resend/services/broadcasts/model/ListBroadcastRecipientsParams.java
@@ -214,8 +214,9 @@ public class ListBroadcastRecipientsParams {
          * Builds a new ListBroadcastRecipientsParams instance.
          *
          * @return A new ListBroadcastRecipientsParams instance.
-         * @throws IllegalArgumentException if {@code type} is not set, or if both {@code after}
-         *         and {@code before} are set.
+         * @throws IllegalArgumentException if {@code type} is not set, if both {@code after}
+         *         and {@code before} are set, or if {@code bounceType} is set while
+         *         {@code type} is not {@code BOUNCED}.
          */
         public ListBroadcastRecipientsParams build() {
             if (type == null) {

--- a/src/main/java/com/resend/services/broadcasts/model/ListBroadcastRecipientsResponseSuccess.java
+++ b/src/main/java/com/resend/services/broadcasts/model/ListBroadcastRecipientsResponseSuccess.java
@@ -1,0 +1,67 @@
+package com.resend.services.broadcasts.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents a successful response for listing a broadcast's recipients.
+ */
+public class ListBroadcastRecipientsResponseSuccess {
+
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("has_more")
+    private Boolean hasMore;
+
+    @JsonProperty("data")
+    private List<BroadcastRecipient> data;
+
+    /**
+     * Default constructor
+     */
+    public ListBroadcastRecipientsResponseSuccess() {
+
+    }
+
+    /**
+     * Constructs a successful response for listing a broadcast's recipients.
+     *
+     * @param object  The object type of the list.
+     * @param hasMore Whether there are more recipients available for pagination.
+     * @param data    The list of broadcast recipients.
+     */
+    public ListBroadcastRecipientsResponseSuccess(String object, Boolean hasMore, List<BroadcastRecipient> data) {
+        this.object = object;
+        this.hasMore = hasMore;
+        this.data = data;
+    }
+
+    /**
+     * Get the object type.
+     *
+     * @return The object type of the list.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Get the indicator whether there are more recipients available for pagination.
+     *
+     * @return Whether there are more recipients available for pagination.
+     */
+    public Boolean hasMore() {
+        return hasMore;
+    }
+
+    /**
+     * Get the list of broadcast recipients.
+     *
+     * @return The list of broadcast recipients.
+     */
+    public List<BroadcastRecipient> getData() {
+        return data;
+    }
+}

--- a/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
+++ b/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
@@ -58,6 +58,28 @@ public class BroadcastsTest {
     private static final String UPDATE_RESPONSE_JSON =
             "{\"id\":\"" + BROADCAST_ID + "\"}";
 
+    private static final String RECIPIENTS_SENT_RESPONSE_JSON =
+            "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
+            "{\"id\":\"b2Zmc2V0OjA\",\"contact_id\":\"e169aa45-1ecf-4183-9955-b1499d5701d3\",\"email\":\"carter@example.com\"}," +
+            "{\"id\":\"b2Zmc2V0OjE\",\"contact_id\":null,\"email\":\"anonymous@example.com\"}" +
+            "]}";
+
+    private static final String RECIPIENTS_OPENED_RESPONSE_JSON =
+            "{\"object\":\"list\",\"has_more\":true,\"data\":[" +
+            "{\"id\":\"b2Zmc2V0OjA\",\"contact_id\":\"e169aa45-1ecf-4183-9955-b1499d5701d3\",\"email\":\"carter@example.com\",\"count\":3}" +
+            "]}";
+
+    private static final String RECIPIENTS_CLICKED_RESPONSE_JSON =
+            "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
+            "{\"id\":\"b2Zmc2V0OjA\",\"contact_id\":\"e169aa45-1ecf-4183-9955-b1499d5701d3\",\"email\":\"carter@example.com\",\"count\":2," +
+            "\"clicked_links\":[{\"url\":\"https://resend.com/pricing\",\"clicks\":2}]}" +
+            "]}";
+
+    private static final String RECIPIENTS_BOUNCED_RESPONSE_JSON =
+            "{\"object\":\"list\",\"has_more\":false,\"data\":[" +
+            "{\"id\":\"b2Zmc2V0OjA\",\"contact_id\":null,\"email\":\"bounced@example.com\",\"bounce_type\":\"permanent\"}" +
+            "]}";
+
     @Mock
     private IHttpClient httpClient;
 
@@ -224,5 +246,127 @@ public class BroadcastsTest {
         assertEquals(BROADCAST_ID, response.getId());
         assertTrue(createOptions.getSend());
         assertNotNull(createOptions.getScheduledAt());
+    }
+
+    @Test
+    public void testRecipients_Success() throws ResendException {
+        ListBroadcastRecipientsParams params = BroadcastsUtil.listBroadcastRecipientsRequest();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, RECIPIENTS_SENT_RESPONSE_JSON, true);
+
+        when(httpClient.perform(eq("/broadcasts/" + GET_BROADCAST_ID + "/recipients?type=sent"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        ListBroadcastRecipientsResponseSuccess response = broadcasts.recipients(GET_BROADCAST_ID, params);
+
+        assertNotNull(response);
+        assertEquals("list", response.getObject());
+        assertFalse(response.hasMore());
+        assertEquals(2, response.getData().size());
+        assertEquals("b2Zmc2V0OjA", response.getData().get(0).getId());
+        assertEquals("e169aa45-1ecf-4183-9955-b1499d5701d3", response.getData().get(0).getContactId());
+        assertEquals("carter@example.com", response.getData().get(0).getEmail());
+        assertNull(response.getData().get(0).getCount());
+        assertNull(response.getData().get(0).getBounceType());
+        assertNull(response.getData().get(0).getClickedLinks());
+        assertNull(response.getData().get(1).getContactId());
+    }
+
+    @Test
+    public void testRecipients_OpenedType_IncludesCount() throws ResendException {
+        ListBroadcastRecipientsParams params = ListBroadcastRecipientsParams.builder()
+                .type(BroadcastRecipientEventType.OPENED)
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, RECIPIENTS_OPENED_RESPONSE_JSON, true);
+
+        when(httpClient.perform(eq("/broadcasts/" + GET_BROADCAST_ID + "/recipients?type=opened"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        ListBroadcastRecipientsResponseSuccess response = broadcasts.recipients(GET_BROADCAST_ID, params);
+
+        assertNotNull(response);
+        assertTrue(response.hasMore());
+        assertEquals(3, response.getData().get(0).getCount());
+        assertNull(response.getData().get(0).getClickedLinks());
+    }
+
+    @Test
+    public void testRecipients_ClickedType_IncludesClickedLinks() throws ResendException {
+        ListBroadcastRecipientsParams params = ListBroadcastRecipientsParams.builder()
+                .type(BroadcastRecipientEventType.CLICKED)
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, RECIPIENTS_CLICKED_RESPONSE_JSON, true);
+
+        when(httpClient.perform(eq("/broadcasts/" + GET_BROADCAST_ID + "/recipients?type=clicked"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        ListBroadcastRecipientsResponseSuccess response = broadcasts.recipients(GET_BROADCAST_ID, params);
+
+        assertNotNull(response);
+        assertEquals(2, response.getData().get(0).getCount());
+        assertEquals(1, response.getData().get(0).getClickedLinks().size());
+        assertEquals("https://resend.com/pricing", response.getData().get(0).getClickedLinks().get(0).getUrl());
+        assertEquals(2, response.getData().get(0).getClickedLinks().get(0).getClicks());
+    }
+
+    @Test
+    public void testRecipients_BouncedTypeWithFilters_Success() throws ResendException {
+        ListBroadcastRecipientsParams params = ListBroadcastRecipientsParams.builder()
+                .type(BroadcastRecipientEventType.BOUNCED)
+                .bounceType(BroadcastRecipientBounceType.PERMANENT)
+                .email("bounced")
+                .limit(10)
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, RECIPIENTS_BOUNCED_RESPONSE_JSON, true);
+
+        when(httpClient.perform(eq("/broadcasts/" + GET_BROADCAST_ID + "/recipients?limit=10&type=bounced&email=bounced&bounce_type=permanent"),
+                anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        ListBroadcastRecipientsResponseSuccess response = broadcasts.recipients(GET_BROADCAST_ID, params);
+
+        assertNotNull(response);
+        assertEquals("permanent", response.getData().get(0).getBounceType());
+        assertNull(response.getData().get(0).getContactId());
+    }
+
+    @Test
+    public void testRecipients_ApiError_ThrowsResendException() throws ResendException {
+        ListBroadcastRecipientsParams params = ListBroadcastRecipientsParams.builder()
+                .type(BroadcastRecipientEventType.SENT)
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(404,
+                "{\"name\":\"not_found\",\"message\":\"Broadcast not found\"}", false);
+
+        when(httpClient.perform(eq("/broadcasts/" + GET_BROADCAST_ID + "/recipients?type=sent"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        ResendException ex = assertThrows(ResendException.class, () -> broadcasts.recipients(GET_BROADCAST_ID, params));
+        assertEquals(404, (int) ex.getStatusCode());
+    }
+
+    @Test
+    public void testListBroadcastRecipientsParams_RequiresType_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> ListBroadcastRecipientsParams.builder().build());
+    }
+
+    @Test
+    public void testListBroadcastRecipientsParams_AfterAndBefore_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> ListBroadcastRecipientsParams.builder()
+                .type(BroadcastRecipientEventType.SENT)
+                .after("cursor_a")
+                .before("cursor_b")
+                .build());
+    }
+
+    @Test
+    public void testListBroadcastRecipientsParams_ToQueryString() {
+        ListBroadcastRecipientsParams params = ListBroadcastRecipientsParams.builder()
+                .type(BroadcastRecipientEventType.CLICKED)
+                .email("carter")
+                .limit(50)
+                .after("cursor_abc")
+                .build();
+
+        assertEquals("?limit=50&after=cursor_abc&type=clicked&email=carter", params.toQueryString());
     }
 }

--- a/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
+++ b/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
@@ -359,6 +359,14 @@ public class BroadcastsTest {
     }
 
     @Test
+    public void testListBroadcastRecipientsParams_BounceTypeRequiresBouncedType_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> ListBroadcastRecipientsParams.builder()
+                .type(BroadcastRecipientEventType.SENT)
+                .bounceType(BroadcastRecipientBounceType.PERMANENT)
+                .build());
+    }
+
+    @Test
     public void testListBroadcastRecipientsParams_ToQueryString() {
         ListBroadcastRecipientsParams params = ListBroadcastRecipientsParams.builder()
                 .type(BroadcastRecipientEventType.CLICKED)

--- a/src/test/java/com/resend/services/util/BroadcastsUtil.java
+++ b/src/test/java/com/resend/services/util/BroadcastsUtil.java
@@ -98,6 +98,12 @@ public class BroadcastsUtil {
                 .build();
     }
 
+    public static ListBroadcastRecipientsParams listBroadcastRecipientsRequest() {
+        return ListBroadcastRecipientsParams.builder()
+                .type(BroadcastRecipientEventType.SENT)
+                .build();
+    }
+
     public static CreateBroadcastOptions createAndScheduleBroadcastRequest() {
         return CreateBroadcastOptions.builder()
                 .audienceId("78261eea-8f8b-4381-83c6-79fa7120f1cf")


### PR DESCRIPTION
Adds `Broadcasts.recipients()` for `GET /broadcasts/{id}/recipients`.

Spec: https://github.com/resend/resend-openapi/pull/97
Node reference: https://github.com/resend/resend-node/pull/1078

Tests: 19/19 broadcast tests. Build clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lists broadcast recipients by event type to enable analytics and filtering in the Java SDK. Clients can page and filter recipients for sent, delivered, opened, clicked, bounced, complained, unsubscribed, and suppressed.

- Adds `Broadcasts.recipients(String id, ListBroadcastRecipientsParams params)` for `GET /broadcasts/{id}/recipients` and returns `ListBroadcastRecipientsResponseSuccess` (`has_more`, `data: BroadcastRecipient[]`); includes `count` for opened/clicked, `clicked_links` for clicked, and `bounce_type` for bounced.
- Params and validation: required `type`; optional `email`, `limit`, and exactly one of `after` or `before`; `bounce_type` only when `type=bounced`. The builder throws `IllegalArgumentException` for invalid combos; non-2xx responses throw `ResendException`. Javadoc now documents the `bounceType` rule.
- New models: `BroadcastRecipient`, `BroadcastRecipientClickedLink`, `BroadcastRecipientEventType`, `BroadcastRecipientBounceType`, `ListBroadcastRecipientsParams`, `ListBroadcastRecipientsResponseSuccess`.

<sup>Written for commit f04b454c63078ea34766246f4e5362e6ad202bd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-java/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

