### PR TITLE
feat: add emails().metrics() for account-level email metrics

### DIFF
--- a/src/main/java/com/resend/services/emails/Emails.java
+++ b/src/main/java/com/resend/services/emails/Emails.java
@@ -317,4 +317,48 @@ public final class Emails extends BaseService {
 
         return resendMapper.readValue(responseBody, ListAttachmentsResponse.class);
     }
+
+    /**
+     * Retrieves aggregate emails metrics (received, delivered, opened, etc.) across the
+     * account, for the default date range and with no breakdown by dimension.
+     *
+     * <p><strong>Note:</strong> this endpoint is currently in beta and might change before
+     * GA.</p>
+     *
+     * @return The emails metrics.
+     * @throws ResendException If an error occurs while retrieving the metrics.
+     */
+    public EmailsMetricsResponse metrics() throws ResendException {
+        return metrics(null);
+    }
+
+    /**
+     * Retrieves aggregate emails metrics (received, delivered, opened, etc.) across the
+     * account, filtered and broken down according to the given options.
+     *
+     * <p><strong>Note:</strong> this endpoint is currently in beta and might change before
+     * GA.</p>
+     *
+     * @param options The metrics query options; can be null.
+     * @return The emails metrics.
+     * @throws ResendException If an error occurs while retrieving the metrics.
+     */
+    public EmailsMetricsResponse metrics(GetEmailsMetricsOptions options) throws ResendException {
+        String pathWithQuery = "/emails/metrics" + (options == null ? "" : options.toQueryString());
+        AbstractHttpResponse<String> response = this.httpClient.perform(
+            pathWithQuery,
+            super.apiKey,
+            HttpMethod.GET,
+            null,
+            MediaType.get("application/json")
+        );
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        return resendMapper.readValue(responseBody, EmailsMetricsResponse.class);
+    }
 }

--- a/src/main/java/com/resend/services/emails/Emails.java
+++ b/src/main/java/com/resend/services/emails/Emails.java
@@ -322,9 +322,6 @@ public final class Emails extends BaseService {
      * Retrieves aggregate emails metrics (received, delivered, opened, etc.) across the
      * account, for the default date range and with no breakdown by dimension.
      *
-     * <p><strong>Note:</strong> this endpoint is currently in beta and might change before
-     * GA.</p>
-     *
      * @return The emails metrics.
      * @throws ResendException If an error occurs while retrieving the metrics.
      */
@@ -335,9 +332,6 @@ public final class Emails extends BaseService {
     /**
      * Retrieves aggregate emails metrics (received, delivered, opened, etc.) across the
      * account, filtered and broken down according to the given options.
-     *
-     * <p><strong>Note:</strong> this endpoint is currently in beta and might change before
-     * GA.</p>
      *
      * @param options The metrics query options; can be null.
      * @return The emails metrics.

--- a/src/main/java/com/resend/services/emails/model/EmailsMetricsDataRow.java
+++ b/src/main/java/com/resend/services/emails/model/EmailsMetricsDataRow.java
@@ -1,0 +1,125 @@
+package com.resend.services.emails.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Represents a single row of the {@code data} array in an emails metrics response.
+ *
+ * <p>Which dimension fields are present depends on the {@code dimensions} that were requested
+ * ({@code period}; {@code domainId}/{@code domainName}; {@code emailId};
+ * {@code broadcastId}/{@code broadcastName}). Any unset dimension is {@code null}.</p>
+ *
+ * <p>Metric values (e.g. {@code delivered}, {@code opened}) are not modeled as fixed fields
+ * since which ones are present depends on the requested {@code metrics}; they are exposed
+ * through {@link #getMetrics()}.</p>
+ *
+ * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
+ * before GA.</p>
+ */
+public class EmailsMetricsDataRow {
+
+    @JsonProperty("period")
+    private String period;
+
+    @JsonProperty("domain_id")
+    private String domainId;
+
+    @JsonProperty("domain_name")
+    private String domainName;
+
+    @JsonProperty("email_id")
+    private String emailId;
+
+    @JsonProperty("broadcast_id")
+    private String broadcastId;
+
+    @JsonProperty("broadcast_name")
+    private String broadcastName;
+
+    private final Map<String, Object> metrics = new LinkedHashMap<>();
+
+    /**
+     * Default constructor for deserialization.
+     */
+    public EmailsMetricsDataRow() {
+    }
+
+    /**
+     * Gets the time bucket for this row, present when {@code period} was a requested dimension.
+     *
+     * @return The period bucket (e.g. {@code 2026-07-01}), or {@code null}.
+     */
+    public String getPeriod() {
+        return period;
+    }
+
+    /**
+     * Gets the sending domain ID for this row, present when {@code domain} was a requested
+     * dimension.
+     *
+     * @return The domain ID, or {@code null}.
+     */
+    public String getDomainId() {
+        return domainId;
+    }
+
+    /**
+     * Gets the sending domain name for this row, present when {@code domain} was a requested
+     * dimension.
+     *
+     * @return The domain name, or {@code null}.
+     */
+    public String getDomainName() {
+        return domainName;
+    }
+
+    /**
+     * Gets the email ID for this row, present when {@code email} was a requested dimension.
+     *
+     * @return The email ID, or {@code null}.
+     */
+    public String getEmailId() {
+        return emailId;
+    }
+
+    /**
+     * Gets the broadcast ID for this row, present when {@code broadcast} was a requested
+     * dimension.
+     *
+     * @return The broadcast ID, or {@code null}.
+     */
+    public String getBroadcastId() {
+        return broadcastId;
+    }
+
+    /**
+     * Gets the broadcast name for this row, present when {@code broadcast} was a requested
+     * dimension.
+     *
+     * @return The broadcast name, or {@code null}.
+     */
+    public String getBroadcastName() {
+        return broadcastName;
+    }
+
+    /**
+     * Gets the requested metric values for this row (e.g. {@code delivered}, {@code opened}),
+     * keyed by metric name.
+     *
+     * @return The metric values for this row.
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getMetrics() {
+        return metrics;
+    }
+
+    @JsonAnySetter
+    void setMetric(String name, Object value) {
+        metrics.put(name, value);
+    }
+}

--- a/src/main/java/com/resend/services/emails/model/EmailsMetricsDataRow.java
+++ b/src/main/java/com/resend/services/emails/model/EmailsMetricsDataRow.java
@@ -17,9 +17,6 @@ import java.util.Map;
  * <p>Metric values (e.g. {@code delivered}, {@code opened}) are not modeled as fixed fields
  * since which ones are present depends on the requested {@code metrics}; they are exposed
  * through {@link #getMetrics()}.</p>
- *
- * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
- * before GA.</p>
  */
 public class EmailsMetricsDataRow {
 

--- a/src/main/java/com/resend/services/emails/model/EmailsMetricsResponse.java
+++ b/src/main/java/com/resend/services/emails/model/EmailsMetricsResponse.java
@@ -10,9 +10,6 @@ import java.util.Map;
  *
  * <p>{@code data} is {@code null} when no {@code dimensions} were requested; in that case only
  * {@code totals} is populated.</p>
- *
- * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
- * before GA.</p>
  */
 public class EmailsMetricsResponse {
 

--- a/src/main/java/com/resend/services/emails/model/EmailsMetricsResponse.java
+++ b/src/main/java/com/resend/services/emails/model/EmailsMetricsResponse.java
@@ -1,0 +1,120 @@
+package com.resend.services.emails.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents the response from {@code GET /emails/metrics}.
+ *
+ * <p>{@code data} is {@code null} when no {@code dimensions} were requested; in that case only
+ * {@code totals} is populated.</p>
+ *
+ * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
+ * before GA.</p>
+ */
+public class EmailsMetricsResponse {
+
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("start_date")
+    private String startDate;
+
+    @JsonProperty("end_date")
+    private String endDate;
+
+    @JsonProperty("metrics")
+    private List<MetricName> metrics;
+
+    @JsonProperty("dimensions")
+    private List<MetricsDimension> dimensions;
+
+    @JsonProperty("granularity")
+    private MetricsGranularity granularity;
+
+    @JsonProperty("totals")
+    private Map<String, Object> totals;
+
+    @JsonProperty("data")
+    private List<EmailsMetricsDataRow> data;
+
+    /**
+     * Default constructor for deserialization.
+     */
+    public EmailsMetricsResponse() {
+    }
+
+    /**
+     * Gets the object type, always {@code metrics}.
+     *
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Gets the resolved start of the date range that was queried.
+     *
+     * @return The start date.
+     */
+    public String getStartDate() {
+        return startDate;
+    }
+
+    /**
+     * Gets the resolved end of the date range that was queried.
+     *
+     * @return The end date.
+     */
+    public String getEndDate() {
+        return endDate;
+    }
+
+    /**
+     * Gets the metrics that were returned.
+     *
+     * @return The returned metrics.
+     */
+    public List<MetricName> getMetrics() {
+        return metrics;
+    }
+
+    /**
+     * Gets the dimensions that were used to break the metrics down.
+     *
+     * @return The dimensions used, empty when the response only contains {@code totals}.
+     */
+    public List<MetricsDimension> getDimensions() {
+        return dimensions;
+    }
+
+    /**
+     * Gets the bucket size used for the {@code period} dimension.
+     *
+     * @return The granularity.
+     */
+    public MetricsGranularity getGranularity() {
+        return granularity;
+    }
+
+    /**
+     * Gets the aggregate totals for each requested metric across the whole date range.
+     *
+     * @return The totals, keyed by metric name.
+     */
+    public Map<String, Object> getTotals() {
+        return totals;
+    }
+
+    /**
+     * Gets the metrics broken down by the requested dimensions.
+     *
+     * @return The data rows, or {@code null} when no dimensions were requested.
+     */
+    public List<EmailsMetricsDataRow> getData() {
+        return data;
+    }
+}

--- a/src/main/java/com/resend/services/emails/model/GetEmailsMetricsOptions.java
+++ b/src/main/java/com/resend/services/emails/model/GetEmailsMetricsOptions.java
@@ -12,10 +12,9 @@ import java.util.stream.Collectors;
 /**
  * Represents the query parameters for {@code GET /emails/metrics}.
  *
- * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
- * before GA. The {@code email} dimension/{@code emailIds} filter cannot be combined with the
- * {@code broadcast} dimension/{@code broadcastIds} filter, in any pairing; {@link Builder#build()}
- * validates this client-side.</p>
+ * <p><strong>Note:</strong> the {@code email} dimension/{@code emailIds} filter cannot be
+ * combined with the {@code broadcast} dimension/{@code broadcastIds} filter, in any pairing;
+ * {@link Builder#build()} validates this client-side.</p>
  */
 public class GetEmailsMetricsOptions {
 
@@ -369,9 +368,16 @@ public class GetEmailsMetricsOptions {
          *
          * @return A new GetEmailsMetricsOptions instance.
          * @throws IllegalArgumentException If the {@code email} dimension/{@code emailIds} filter
-         *     is combined with the {@code broadcast} dimension/{@code broadcastIds} filter.
+         *     is combined with the {@code broadcast} dimension/{@code broadcastIds} filter, or if
+         *     {@code domainIds}, {@code emailIds}, or {@code broadcastIds} has more than 100 entries.
          */
         public GetEmailsMetricsOptions build() {
+            if ((domainIds != null && domainIds.size() > 100)
+                    || (emailIds != null && emailIds.size() > 100)
+                    || (broadcastIds != null && broadcastIds.size() > 100)) {
+                throw new IllegalArgumentException(
+                        "domainIds, emailIds, and broadcastIds can have at most 100 entries each");
+            }
             boolean hasEmail = (emailIds != null && !emailIds.isEmpty())
                     || (dimensions != null && dimensions.contains(MetricsDimension.EMAIL));
             boolean hasBroadcast = (broadcastIds != null && !broadcastIds.isEmpty())

--- a/src/main/java/com/resend/services/emails/model/GetEmailsMetricsOptions.java
+++ b/src/main/java/com/resend/services/emails/model/GetEmailsMetricsOptions.java
@@ -13,10 +13,9 @@ import java.util.stream.Collectors;
  * Represents the query parameters for {@code GET /emails/metrics}.
  *
  * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
- * before GA. The API validates that {@code email} is not combined with the {@code broadcast}
- * dimension (or {@code broadcastIds}), and that {@code broadcastIds} is not combined with the
- * {@code email} dimension (or {@code emailIds}); this SDK does not pre-validate those
- * combinations client-side.</p>
+ * before GA. The {@code email} dimension/{@code emailIds} filter cannot be combined with the
+ * {@code broadcast} dimension/{@code broadcastIds} filter, in any pairing; {@link Builder#build()}
+ * validates this client-side.</p>
  */
 public class GetEmailsMetricsOptions {
 
@@ -369,8 +368,18 @@ public class GetEmailsMetricsOptions {
          * Builds a new GetEmailsMetricsOptions instance.
          *
          * @return A new GetEmailsMetricsOptions instance.
+         * @throws IllegalArgumentException If the {@code email} dimension/{@code emailIds} filter
+         *     is combined with the {@code broadcast} dimension/{@code broadcastIds} filter.
          */
         public GetEmailsMetricsOptions build() {
+            boolean hasEmail = (emailIds != null && !emailIds.isEmpty())
+                    || (dimensions != null && dimensions.contains(MetricsDimension.EMAIL));
+            boolean hasBroadcast = (broadcastIds != null && !broadcastIds.isEmpty())
+                    || (dimensions != null && dimensions.contains(MetricsDimension.BROADCAST));
+            if (hasEmail && hasBroadcast) {
+                throw new IllegalArgumentException(
+                        "The `email` dimension/emailIds filter cannot be combined with the `broadcast` dimension/broadcastIds filter");
+            }
             return new GetEmailsMetricsOptions(this);
         }
     }

--- a/src/main/java/com/resend/services/emails/model/GetEmailsMetricsOptions.java
+++ b/src/main/java/com/resend/services/emails/model/GetEmailsMetricsOptions.java
@@ -1,0 +1,377 @@
+package com.resend.services.emails.model;
+
+import com.resend.core.helper.URLHelper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Represents the query parameters for {@code GET /emails/metrics}.
+ *
+ * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
+ * before GA. The API validates that {@code email} is not combined with the {@code broadcast}
+ * dimension (or {@code broadcastIds}), and that {@code broadcastIds} is not combined with the
+ * {@code email} dimension (or {@code emailIds}); this SDK does not pre-validate those
+ * combinations client-side.</p>
+ */
+public class GetEmailsMetricsOptions {
+
+    private final String startDate;
+    private final String endDate;
+    private final String timezone;
+    private final MetricsGranularity granularity;
+    private final List<MetricName> metrics;
+    private final List<MetricsDimension> dimensions;
+    private final List<String> domainIds;
+    private final List<String> emailIds;
+    private final List<String> broadcastIds;
+
+    /**
+     * Constructs a GetEmailsMetricsOptions object using the provided builder.
+     *
+     * @param builder The builder to construct the GetEmailsMetricsOptions.
+     */
+    public GetEmailsMetricsOptions(Builder builder) {
+        this.startDate = builder.startDate;
+        this.endDate = builder.endDate;
+        this.timezone = builder.timezone;
+        this.granularity = builder.granularity;
+        this.metrics = builder.metrics;
+        this.dimensions = builder.dimensions;
+        this.domainIds = builder.domainIds;
+        this.emailIds = builder.emailIds;
+        this.broadcastIds = builder.broadcastIds;
+    }
+
+    /**
+     * Gets the start of the date range, as an ISO 8601 date or datetime.
+     *
+     * @return The start date.
+     */
+    public String getStartDate() {
+        return startDate;
+    }
+
+    /**
+     * Gets the end of the date range, as an ISO 8601 date or datetime.
+     *
+     * @return The end date.
+     */
+    public String getEndDate() {
+        return endDate;
+    }
+
+    /**
+     * Gets the IANA timezone used to bucket metrics (e.g. {@code America/New_York}).
+     *
+     * @return The timezone.
+     */
+    public String getTimezone() {
+        return timezone;
+    }
+
+    /**
+     * Gets the bucket size used when {@code period} is included in {@link #getDimensions()}.
+     *
+     * @return The granularity.
+     */
+    public MetricsGranularity getGranularity() {
+        return granularity;
+    }
+
+    /**
+     * Gets the metrics to return. Defaults to all metrics when not set.
+     *
+     * @return The requested metrics.
+     */
+    public List<MetricName> getMetrics() {
+        return metrics;
+    }
+
+    /**
+     * Gets the dimensions to break metrics down by. Defaults to none, in which case the
+     * response only contains {@code totals}.
+     *
+     * @return The requested dimensions.
+     */
+    public List<MetricsDimension> getDimensions() {
+        return dimensions;
+    }
+
+    /**
+     * Gets the sending domain IDs to filter by (max 100).
+     *
+     * @return The domain ID filter.
+     */
+    public List<String> getDomainIds() {
+        return domainIds;
+    }
+
+    /**
+     * Gets the email IDs to filter by (max 100).
+     *
+     * @return The email ID filter.
+     */
+    public List<String> getEmailIds() {
+        return emailIds;
+    }
+
+    /**
+     * Gets the broadcast IDs to filter by (max 100).
+     *
+     * @return The broadcast ID filter.
+     */
+    public List<String> getBroadcastIds() {
+        return broadcastIds;
+    }
+
+    /**
+     * Converts the parameters to a query string.
+     *
+     * @return A query string starting with "?" if parameters exist, or an empty string otherwise.
+     */
+    public String toQueryString() {
+        Map<String, String> extras = new LinkedHashMap<>();
+
+        if (startDate != null && !startDate.isEmpty()) {
+            extras.put("start_date", startDate);
+        }
+        if (endDate != null && !endDate.isEmpty()) {
+            extras.put("end_date", endDate);
+        }
+        if (timezone != null && !timezone.isEmpty()) {
+            extras.put("timezone", timezone);
+        }
+        if (granularity != null) {
+            extras.put("granularity", granularity.getValue());
+        }
+        if (metrics != null && !metrics.isEmpty()) {
+            extras.put("metrics", metrics.stream().map(MetricName::getValue).collect(Collectors.joining(",")));
+        }
+        if (dimensions != null && !dimensions.isEmpty()) {
+            extras.put("dimensions", dimensions.stream().map(MetricsDimension::getValue).collect(Collectors.joining(",")));
+        }
+        if (domainIds != null && !domainIds.isEmpty()) {
+            extras.put("domain_id", String.join(",", domainIds));
+        }
+        if (emailIds != null && !emailIds.isEmpty()) {
+            extras.put("email_id", String.join(",", emailIds));
+        }
+        if (broadcastIds != null && !broadcastIds.isEmpty()) {
+            extras.put("broadcast_id", String.join(",", broadcastIds));
+        }
+
+        return URLHelper.parse(null, extras);
+    }
+
+    /**
+     * Creates a new builder instance for constructing GetEmailsMetricsOptions objects.
+     *
+     * @return A new builder instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing GetEmailsMetricsOptions objects.
+     */
+    public static class Builder {
+        /**
+         * Creates a new Builder instance.
+         */
+        public Builder() {
+        }
+
+        private String startDate;
+        private String endDate;
+        private String timezone;
+        private MetricsGranularity granularity;
+        private List<MetricName> metrics;
+        private List<MetricsDimension> dimensions;
+        private List<String> domainIds;
+        private List<String> emailIds;
+        private List<String> broadcastIds;
+
+        /**
+         * Sets the start of the date range (ISO 8601 date or datetime). Defaults server-side
+         * to 6 days before {@code endDate}.
+         *
+         * @param startDate The start date.
+         * @return The builder instance.
+         */
+        public Builder startDate(String startDate) {
+            this.startDate = startDate;
+            return this;
+        }
+
+        /**
+         * Sets the end of the date range (ISO 8601 date or datetime). Defaults server-side to
+         * now.
+         *
+         * @param endDate The end date.
+         * @return The builder instance.
+         */
+        public Builder endDate(String endDate) {
+            this.endDate = endDate;
+            return this;
+        }
+
+        /**
+         * Sets the IANA timezone used to bucket metrics (e.g. {@code America/New_York}).
+         * Defaults server-side to {@code UTC}.
+         *
+         * @param timezone The timezone.
+         * @return The builder instance.
+         */
+        public Builder timezone(String timezone) {
+            this.timezone = timezone;
+            return this;
+        }
+
+        /**
+         * Sets the bucket size used when {@code period} is included in the requested
+         * dimensions. Defaults server-side to {@code daily}.
+         *
+         * @param granularity The granularity.
+         * @return The builder instance.
+         */
+        public Builder granularity(MetricsGranularity granularity) {
+            this.granularity = granularity;
+            return this;
+        }
+
+        /**
+         * Sets the metrics to return, replacing any previously set metrics.
+         *
+         * @param metrics The metrics to return.
+         * @return The builder instance.
+         */
+        public Builder metrics(List<MetricName> metrics) {
+            this.metrics = metrics;
+            return this;
+        }
+
+        /**
+         * Sets the metrics to return, replacing any previously set metrics.
+         *
+         * @param metrics The metrics to return.
+         * @return The builder instance.
+         */
+        public Builder metrics(MetricName... metrics) {
+            this.metrics = new ArrayList<>(Arrays.asList(metrics));
+            return this;
+        }
+
+        /**
+         * Sets the dimensions to break metrics down by, replacing any previously set
+         * dimensions.
+         *
+         * @param dimensions The dimensions.
+         * @return The builder instance.
+         */
+        public Builder dimensions(List<MetricsDimension> dimensions) {
+            this.dimensions = dimensions;
+            return this;
+        }
+
+        /**
+         * Sets the dimensions to break metrics down by, replacing any previously set
+         * dimensions.
+         *
+         * @param dimensions The dimensions.
+         * @return The builder instance.
+         */
+        public Builder dimensions(MetricsDimension... dimensions) {
+            this.dimensions = new ArrayList<>(Arrays.asList(dimensions));
+            return this;
+        }
+
+        /**
+         * Sets the sending domain IDs to filter by (max 100), replacing any previously set
+         * domain IDs.
+         *
+         * @param domainIds The domain ID filter.
+         * @return The builder instance.
+         */
+        public Builder domainIds(List<String> domainIds) {
+            this.domainIds = domainIds;
+            return this;
+        }
+
+        /**
+         * Sets the sending domain IDs to filter by (max 100), replacing any previously set
+         * domain IDs.
+         *
+         * @param domainIds The domain ID filter.
+         * @return The builder instance.
+         */
+        public Builder domainIds(String... domainIds) {
+            this.domainIds = new ArrayList<>(Arrays.asList(domainIds));
+            return this;
+        }
+
+        /**
+         * Sets the email IDs to filter by (max 100), replacing any previously set email IDs.
+         * Cannot be combined with the {@code broadcast} dimension or {@code broadcastIds}.
+         *
+         * @param emailIds The email ID filter.
+         * @return The builder instance.
+         */
+        public Builder emailIds(List<String> emailIds) {
+            this.emailIds = emailIds;
+            return this;
+        }
+
+        /**
+         * Sets the email IDs to filter by (max 100), replacing any previously set email IDs.
+         * Cannot be combined with the {@code broadcast} dimension or {@code broadcastIds}.
+         *
+         * @param emailIds The email ID filter.
+         * @return The builder instance.
+         */
+        public Builder emailIds(String... emailIds) {
+            this.emailIds = new ArrayList<>(Arrays.asList(emailIds));
+            return this;
+        }
+
+        /**
+         * Sets the broadcast IDs to filter by (max 100), replacing any previously set
+         * broadcast IDs. Cannot be combined with the {@code email} dimension or
+         * {@code emailIds}.
+         *
+         * @param broadcastIds The broadcast ID filter.
+         * @return The builder instance.
+         */
+        public Builder broadcastIds(List<String> broadcastIds) {
+            this.broadcastIds = broadcastIds;
+            return this;
+        }
+
+        /**
+         * Sets the broadcast IDs to filter by (max 100), replacing any previously set
+         * broadcast IDs. Cannot be combined with the {@code email} dimension or
+         * {@code emailIds}.
+         *
+         * @param broadcastIds The broadcast ID filter.
+         * @return The builder instance.
+         */
+        public Builder broadcastIds(String... broadcastIds) {
+            this.broadcastIds = new ArrayList<>(Arrays.asList(broadcastIds));
+            return this;
+        }
+
+        /**
+         * Builds a new GetEmailsMetricsOptions instance.
+         *
+         * @return A new GetEmailsMetricsOptions instance.
+         */
+        public GetEmailsMetricsOptions build() {
+            return new GetEmailsMetricsOptions(this);
+        }
+    }
+}

--- a/src/main/java/com/resend/services/emails/model/MetricName.java
+++ b/src/main/java/com/resend/services/emails/model/MetricName.java
@@ -1,0 +1,90 @@
+package com.resend.services.emails.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents a metric that can be requested from the {@code GET /emails/metrics} endpoint.
+ *
+ * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
+ * before GA.</p>
+ */
+public enum MetricName {
+    /** Number of emails received for processing. */
+    RECEIVED("received"),
+    /** Number of emails delivered. */
+    DELIVERED("delivered"),
+    /** Number of emails that received a spam complaint. */
+    COMPLAINED("complained"),
+    /** Number of emails suppressed before sending. */
+    SUPPRESSED("suppressed"),
+    /** Number of emails that bounced, of any kind. */
+    BOUNCED("bounced"),
+    /** Number of emails that bounced transiently. */
+    BOUNCED_TRANSIENT("bounced_transient"),
+    /** Number of emails that bounced permanently. */
+    BOUNCED_PERMANENT("bounced_permanent"),
+    /** Number of emails that bounced for an undetermined reason. */
+    BOUNCED_UNDETERMINED("bounced_undetermined"),
+    /** Number of emails opened, counting every open event. */
+    OPENED("opened"),
+    /** Number of link clicks, counting every click event. */
+    CLICKED("clicked"),
+    /** Number of unsubscribes. */
+    UNSUBSCRIBED("unsubscribed"),
+    /** Number of emails whose delivery was delayed. */
+    DELIVERY_DELAYED("delivery_delayed"),
+    /** Number of emails that failed to send. */
+    FAILED("failed"),
+    /** Number of emails sent. */
+    SENT("sent"),
+    /** Number of emails opened at least once. */
+    UNIQUE_OPENED("unique_opened"),
+    /** Number of emails clicked at least once. */
+    UNIQUE_CLICKED("unique_clicked"),
+    /** Ratio of delivered emails to sent emails. */
+    DELIVERY_RATE("delivery_rate"),
+    /** Ratio of emails opened to emails delivered. */
+    OPEN_RATE("open_rate"),
+    /** Ratio of emails clicked to emails delivered. */
+    CLICK_RATE("click_rate"),
+    /** Ratio of emails bounced to emails sent. */
+    BOUNCE_RATE("bounce_rate"),
+    /** Ratio of complaints to emails delivered. */
+    COMPLAINT_RATE("complaint_rate"),
+    /** Ratio of unsubscribes to emails delivered. */
+    UNSUBSCRIBE_RATE("unsubscribe_rate");
+
+    private final String value;
+
+    MetricName(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the string value of the metric.
+     *
+     * @return The metric value.
+     */
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Creates a MetricName from a string value.
+     *
+     * @param value The string value.
+     * @return The corresponding MetricName.
+     * @throws IllegalArgumentException If the value is unknown.
+     */
+    @JsonCreator
+    public static MetricName fromValue(String value) {
+        for (MetricName metric : MetricName.values()) {
+            if (metric.value.equals(value)) {
+                return metric;
+            }
+        }
+        throw new IllegalArgumentException("Unknown metric: " + value);
+    }
+}

--- a/src/main/java/com/resend/services/emails/model/MetricName.java
+++ b/src/main/java/com/resend/services/emails/model/MetricName.java
@@ -5,9 +5,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Represents a metric that can be requested from the {@code GET /emails/metrics} endpoint.
- *
- * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
- * before GA.</p>
  */
 public enum MetricName {
     /** Number of emails received for processing. */

--- a/src/main/java/com/resend/services/emails/model/MetricsDimension.java
+++ b/src/main/java/com/resend/services/emails/model/MetricsDimension.java
@@ -1,0 +1,57 @@
+package com.resend.services.emails.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents a dimension that emails metrics can be broken down by.
+ *
+ * <p>{@code EMAIL} and {@code BROADCAST} cannot be combined; the API validates this and
+ * returns a 422 response, this SDK does not pre-validate it.</p>
+ *
+ * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
+ * before GA.</p>
+ */
+public enum MetricsDimension {
+    /** Breaks metrics down by time bucket, sized by the requested granularity. */
+    PERIOD("period"),
+    /** Breaks metrics down by sending domain. */
+    DOMAIN("domain"),
+    /** Breaks metrics down by individual email. */
+    EMAIL("email"),
+    /** Breaks metrics down by broadcast. */
+    BROADCAST("broadcast");
+
+    private final String value;
+
+    MetricsDimension(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the string value of the dimension.
+     *
+     * @return The dimension value.
+     */
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Creates a MetricsDimension from a string value.
+     *
+     * @param value The string value.
+     * @return The corresponding MetricsDimension.
+     * @throws IllegalArgumentException If the value is unknown.
+     */
+    @JsonCreator
+    public static MetricsDimension fromValue(String value) {
+        for (MetricsDimension dimension : MetricsDimension.values()) {
+            if (dimension.value.equals(value)) {
+                return dimension;
+            }
+        }
+        throw new IllegalArgumentException("Unknown dimension: " + value);
+    }
+}

--- a/src/main/java/com/resend/services/emails/model/MetricsDimension.java
+++ b/src/main/java/com/resend/services/emails/model/MetricsDimension.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * Represents a dimension that emails metrics can be broken down by.
  *
- * <p>{@code EMAIL} and {@code BROADCAST} cannot be combined; the API validates this and
- * returns a 422 response, this SDK does not pre-validate it.</p>
+ * <p>{@code EMAIL} and {@code BROADCAST} cannot be combined; {@link GetEmailsMetricsOptions.Builder#build()}
+ * validates this client-side.</p>
  *
  * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
  * before GA.</p>

--- a/src/main/java/com/resend/services/emails/model/MetricsDimension.java
+++ b/src/main/java/com/resend/services/emails/model/MetricsDimension.java
@@ -8,9 +8,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
  *
  * <p>{@code EMAIL} and {@code BROADCAST} cannot be combined; {@link GetEmailsMetricsOptions.Builder#build()}
  * validates this client-side.</p>
- *
- * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
- * before GA.</p>
  */
 public enum MetricsDimension {
     /** Breaks metrics down by time bucket, sized by the requested granularity. */

--- a/src/main/java/com/resend/services/emails/model/MetricsGranularity.java
+++ b/src/main/java/com/resend/services/emails/model/MetricsGranularity.java
@@ -1,0 +1,54 @@
+package com.resend.services.emails.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents the time bucket size used for the {@code period} dimension of emails metrics.
+ *
+ * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
+ * before GA.</p>
+ */
+public enum MetricsGranularity {
+    /** Buckets metrics by hour. */
+    HOURLY("hourly"),
+    /** Buckets metrics by day. */
+    DAILY("daily"),
+    /** Buckets metrics by week. */
+    WEEKLY("weekly"),
+    /** Buckets metrics by month. */
+    MONTHLY("monthly");
+
+    private final String value;
+
+    MetricsGranularity(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the string value of the granularity.
+     *
+     * @return The granularity value.
+     */
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Creates a MetricsGranularity from a string value.
+     *
+     * @param value The string value.
+     * @return The corresponding MetricsGranularity.
+     * @throws IllegalArgumentException If the value is unknown.
+     */
+    @JsonCreator
+    public static MetricsGranularity fromValue(String value) {
+        for (MetricsGranularity granularity : MetricsGranularity.values()) {
+            if (granularity.value.equals(value)) {
+                return granularity;
+            }
+        }
+        throw new IllegalArgumentException("Unknown granularity: " + value);
+    }
+}

--- a/src/main/java/com/resend/services/emails/model/MetricsGranularity.java
+++ b/src/main/java/com/resend/services/emails/model/MetricsGranularity.java
@@ -5,9 +5,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Represents the time bucket size used for the {@code period} dimension of emails metrics.
- *
- * <p><strong>Note:</strong> the emails metrics endpoint is currently in beta and might change
- * before GA.</p>
  */
 public enum MetricsGranularity {
     /** Buckets metrics by hour. */

--- a/src/test/java/com/resend/services/emails/EmailsTest.java
+++ b/src/test/java/com/resend/services/emails/EmailsTest.java
@@ -64,6 +64,41 @@ public class EmailsTest {
             "{\"object\":\"attachment\",\"id\":\"3b0d9ce0-4223-5839-087f-58eede27b429\",\"filename\":\"invoice.pdf\",\"size\":8192,\"content_type\":\"application/pdf\"}" +
             "]}";
 
+    private static final String METRICS_TOTALS_ONLY_JSON =
+            "{\"object\":\"metrics\",\"start_date\":\"2026-07-01T00:00:00.000Z\"," +
+            "\"end_date\":\"2026-07-08T00:00:00.000Z\",\"metrics\":[\"delivered\",\"opened\"]," +
+            "\"dimensions\":[],\"granularity\":\"daily\"," +
+            "\"totals\":{\"delivered\":100,\"opened\":40}}";
+
+    private static final String METRICS_WITH_PERIOD_JSON =
+            "{\"object\":\"metrics\",\"start_date\":\"2026-07-01T00:00:00.000Z\"," +
+            "\"end_date\":\"2026-07-08T00:00:00.000Z\",\"metrics\":[\"delivered\"]," +
+            "\"dimensions\":[\"period\"],\"granularity\":\"daily\"," +
+            "\"totals\":{\"delivered\":10},\"data\":[" +
+            "{\"period\":\"2026-07-01\",\"delivered\":10}]}";
+
+    private static final String METRICS_WITH_DOMAIN_JSON =
+            "{\"object\":\"metrics\",\"start_date\":\"2026-07-01T00:00:00.000Z\"," +
+            "\"end_date\":\"2026-07-08T00:00:00.000Z\",\"metrics\":[\"delivered\"]," +
+            "\"dimensions\":[\"domain\"],\"granularity\":\"daily\"," +
+            "\"totals\":{\"delivered\":10},\"data\":[" +
+            "{\"domain_id\":\"d1\",\"domain_name\":\"example.com\",\"delivered\":10}]}";
+
+    private static final String METRICS_WITH_EMAIL_JSON =
+            "{\"object\":\"metrics\",\"start_date\":\"2026-07-01T00:00:00.000Z\"," +
+            "\"end_date\":\"2026-07-08T00:00:00.000Z\",\"metrics\":[\"delivered\"]," +
+            "\"dimensions\":[\"email\"],\"granularity\":\"daily\"," +
+            "\"totals\":{\"delivered\":10},\"data\":[" +
+            "{\"email_id\":\"e1\",\"delivered\":10}]}";
+
+    private static final String METRICS_WITH_BROADCAST_JSON =
+            "{\"object\":\"metrics\",\"start_date\":\"2026-07-01T00:00:00.000Z\"," +
+            "\"end_date\":\"2026-07-08T00:00:00.000Z\",\"metrics\":[\"delivered\",\"opened\"]," +
+            "\"dimensions\":[\"period\",\"broadcast\"],\"granularity\":\"daily\"," +
+            "\"totals\":{\"delivered\":100,\"opened\":40},\"data\":[" +
+            "{\"period\":\"2026-07-01\",\"broadcast_id\":\"uuid\",\"broadcast_name\":\"July Newsletter\"," +
+            "\"delivered\":10,\"opened\":4}]}";
+
     @Mock
     private IHttpClient httpClient;
 
@@ -309,5 +344,259 @@ public class EmailsTest {
 
         assertNotNull(response);
         assertEquals("mock_id", response.getId());
+    }
+
+    @Test
+    public void testGetEmailsMetrics_NoOptions_Success() throws ResendException {
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_TOTALS_ONLY_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics();
+
+        assertNotNull(response);
+        assertEquals("metrics", response.getObject());
+        assertEquals("2026-07-01T00:00:00.000Z", response.getStartDate());
+        assertEquals("2026-07-08T00:00:00.000Z", response.getEndDate());
+        assertEquals(MetricsGranularity.DAILY, response.getGranularity());
+        assertEquals(2, response.getMetrics().size());
+        assertTrue(response.getDimensions().isEmpty());
+        assertNull(response.getData());
+        assertEquals(100, response.getTotals().get("delivered"));
+        assertEquals(40, response.getTotals().get("opened"));
+    }
+
+    @Test
+    public void testGetEmailsMetrics_NullOptions_Success() throws ResendException {
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_TOTALS_ONLY_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(null);
+
+        assertNotNull(response);
+        assertEquals("metrics", response.getObject());
+    }
+
+    @Test
+    public void testGetEmailsMetrics_DimensionPeriod_Success() throws ResendException {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .dimensions(MetricsDimension.PERIOD)
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_WITH_PERIOD_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics?dimensions=period"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(options);
+
+        assertNotNull(response);
+        assertEquals(1, response.getData().size());
+        assertEquals("2026-07-01", response.getData().get(0).getPeriod());
+        assertEquals(10, response.getData().get(0).getMetrics().get("delivered"));
+    }
+
+    @Test
+    public void testGetEmailsMetrics_DimensionDomain_Success() throws ResendException {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .dimensions(MetricsDimension.DOMAIN)
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_WITH_DOMAIN_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics?dimensions=domain"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(options);
+
+        assertNotNull(response);
+        assertEquals("d1", response.getData().get(0).getDomainId());
+        assertEquals("example.com", response.getData().get(0).getDomainName());
+    }
+
+    @Test
+    public void testGetEmailsMetrics_DimensionEmail_Success() throws ResendException {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .dimensions(MetricsDimension.EMAIL)
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_WITH_EMAIL_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics?dimensions=email"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(options);
+
+        assertNotNull(response);
+        assertEquals("e1", response.getData().get(0).getEmailId());
+    }
+
+    @Test
+    public void testGetEmailsMetrics_DimensionBroadcast_Success() throws ResendException {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .dimensions(MetricsDimension.PERIOD, MetricsDimension.BROADCAST)
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_WITH_BROADCAST_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics?dimensions=period%2Cbroadcast"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(options);
+
+        assertNotNull(response);
+        assertEquals("2026-07-01", response.getData().get(0).getPeriod());
+        assertEquals("uuid", response.getData().get(0).getBroadcastId());
+        assertEquals("July Newsletter", response.getData().get(0).getBroadcastName());
+        assertEquals(10, response.getData().get(0).getMetrics().get("delivered"));
+        assertEquals(4, response.getData().get(0).getMetrics().get("opened"));
+    }
+
+    @Test
+    public void testGetEmailsMetrics_DomainIdFilter_SingleValue_Success() throws ResendException {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .domainIds("d1")
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_TOTALS_ONLY_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics?domain_id=d1"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(options);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void testGetEmailsMetrics_DomainIdFilter_MultipleValues_Success() throws ResendException {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .domainIds("d1", "d2")
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_TOTALS_ONLY_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics?domain_id=d1%2Cd2"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(options);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void testGetEmailsMetrics_EmailIdFilter_SingleValue_Success() throws ResendException {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .emailIds("e1")
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_TOTALS_ONLY_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics?email_id=e1"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(options);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void testGetEmailsMetrics_EmailIdFilter_MultipleValues_Success() throws ResendException {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .emailIds("e1", "e2")
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_TOTALS_ONLY_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics?email_id=e1%2Ce2"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(options);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void testGetEmailsMetrics_BroadcastIdFilter_SingleValue_Success() throws ResendException {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .broadcastIds("b1")
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_TOTALS_ONLY_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics?broadcast_id=b1"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(options);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void testGetEmailsMetrics_BroadcastIdFilter_MultipleValues_Success() throws ResendException {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .broadcastIds("b1", "b2")
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_TOTALS_ONLY_JSON, true);
+
+        when(httpClient.perform(eq("/emails/metrics?broadcast_id=b1%2Cb2"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(options);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void testGetEmailsMetrics_MetricsGranularityTimezone_PassedThrough() throws ResendException {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .metrics(MetricName.DELIVERED, MetricName.OPENED)
+                .granularity(MetricsGranularity.WEEKLY)
+                .timezone("America/New_York")
+                .build();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, METRICS_TOTALS_ONLY_JSON, true);
+
+        when(httpClient.perform(
+                eq("/emails/metrics?timezone=America%2FNew_York&granularity=weekly&metrics=delivered%2Copened"),
+                anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        EmailsMetricsResponse response = emails.metrics(options);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void testGetEmailsMetricsOptions_ToQueryString_AllParams() {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .startDate("2026-07-01")
+                .endDate("2026-07-08")
+                .timezone("UTC")
+                .granularity(MetricsGranularity.DAILY)
+                .metrics(MetricName.DELIVERED, MetricName.OPENED)
+                .dimensions(MetricsDimension.PERIOD, MetricsDimension.BROADCAST)
+                .domainIds("d1")
+                .emailIds("e1")
+                .broadcastIds("b1", "b2")
+                .build();
+
+        assertEquals(
+                "?start_date=2026-07-01&end_date=2026-07-08&timezone=UTC&granularity=daily" +
+                "&metrics=delivered%2Copened&dimensions=period%2Cbroadcast&domain_id=d1" +
+                "&email_id=e1&broadcast_id=b1%2Cb2",
+                options.toQueryString());
+    }
+
+    @Test
+    public void testGetEmailsMetricsOptions_ToQueryString_Empty() {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder().build();
+
+        assertEquals("", options.toQueryString());
+    }
+
+    @Test
+    public void testGetEmailsMetrics_ApiError_ThrowsResendException() throws ResendException {
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(422,
+                "{\"name\":\"validation_error\",\"message\":\"email cannot be combined with broadcast\"}", false);
+
+        when(httpClient.perform(eq("/emails/metrics"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        ResendException ex = assertThrows(ResendException.class, () -> emails.metrics());
+        assertEquals(422, (int) ex.getStatusCode());
     }
 }

--- a/src/test/java/com/resend/services/emails/EmailsTest.java
+++ b/src/test/java/com/resend/services/emails/EmailsTest.java
@@ -8,6 +8,7 @@ import com.resend.core.net.ListParams;
 import com.resend.core.net.RequestOptions;
 import com.resend.services.emails.model.*;
 import com.resend.services.util.EmailsUtil;
+import java.util.Collections;
 import okhttp3.MediaType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -615,6 +616,13 @@ public class EmailsTest {
         assertThrows(IllegalArgumentException.class, () -> GetEmailsMetricsOptions.builder()
                 .emailIds("e1")
                 .broadcastIds("b1")
+                .build());
+    }
+
+    @Test
+    public void testGetEmailsMetricsOptions_Build_RejectsMoreThan100DomainIds() {
+        assertThrows(IllegalArgumentException.class, () -> GetEmailsMetricsOptions.builder()
+                .domainIds(Collections.nCopies(101, "d1"))
                 .build());
     }
 

--- a/src/test/java/com/resend/services/emails/EmailsTest.java
+++ b/src/test/java/com/resend/services/emails/EmailsTest.java
@@ -570,14 +570,13 @@ public class EmailsTest {
                 .metrics(MetricName.DELIVERED, MetricName.OPENED)
                 .dimensions(MetricsDimension.PERIOD, MetricsDimension.BROADCAST)
                 .domainIds("d1")
-                .emailIds("e1")
                 .broadcastIds("b1", "b2")
                 .build();
 
         assertEquals(
                 "?start_date=2026-07-01&end_date=2026-07-08&timezone=UTC&granularity=daily" +
                 "&metrics=delivered%2Copened&dimensions=period%2Cbroadcast&domain_id=d1" +
-                "&email_id=e1&broadcast_id=b1%2Cb2",
+                "&broadcast_id=b1%2Cb2",
                 options.toQueryString());
     }
 
@@ -586,6 +585,46 @@ public class EmailsTest {
         GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder().build();
 
         assertEquals("", options.toQueryString());
+    }
+
+    @Test
+    public void testGetEmailsMetricsOptions_Build_RejectsEmailAndBroadcastDimensions() {
+        assertThrows(IllegalArgumentException.class, () -> GetEmailsMetricsOptions.builder()
+                .dimensions(MetricsDimension.EMAIL, MetricsDimension.BROADCAST)
+                .build());
+    }
+
+    @Test
+    public void testGetEmailsMetricsOptions_Build_RejectsBroadcastDimensionWithEmailIds() {
+        assertThrows(IllegalArgumentException.class, () -> GetEmailsMetricsOptions.builder()
+                .dimensions(MetricsDimension.BROADCAST)
+                .emailIds("e1")
+                .build());
+    }
+
+    @Test
+    public void testGetEmailsMetricsOptions_Build_RejectsEmailDimensionWithBroadcastIds() {
+        assertThrows(IllegalArgumentException.class, () -> GetEmailsMetricsOptions.builder()
+                .dimensions(MetricsDimension.EMAIL)
+                .broadcastIds("b1")
+                .build());
+    }
+
+    @Test
+    public void testGetEmailsMetricsOptions_Build_RejectsEmailIdsWithBroadcastIds() {
+        assertThrows(IllegalArgumentException.class, () -> GetEmailsMetricsOptions.builder()
+                .emailIds("e1")
+                .broadcastIds("b1")
+                .build());
+    }
+
+    @Test
+    public void testGetEmailsMetricsOptions_Build_AllowsDomainAndBroadcastDimensionsCombined() {
+        GetEmailsMetricsOptions options = GetEmailsMetricsOptions.builder()
+                .dimensions(MetricsDimension.DOMAIN, MetricsDimension.BROADCAST)
+                .build();
+
+        assertEquals("?dimensions=domain%2Cbroadcast", options.toQueryString());
     }
 
     @Test


### PR DESCRIPTION
Adds `emails().metrics()` for account-level email metrics via `GET /emails/metrics` — `period`/`domain`/`email`/`broadcast` dimensions, `domain_id`/`email_id`/`broadcast_id` filters (`broadcast` and `email` mutually exclusive), `hourly`/`daily`/`weekly`/`monthly` granularity.

Mirrors https://github.com/resend/resend-node/pull/1079. Spec: https://github.com/resend/resend-openapi/pull/96