### PR TITLE
feat(webhooks): add event listing endpoints

### DIFF
--- a/src/main/java/com/resend/services/webhooks/Webhooks.java
+++ b/src/main/java/com/resend/services/webhooks/Webhooks.java
@@ -137,10 +137,25 @@ public final class Webhooks extends BaseService {
         return resendMapper.readValue(responseBody, ListWebhooksResponseSuccess.class);
     }
 
+    /**
+     * Retrieves a list of events delivered to a webhook.
+     *
+     * @param webhookId The unique identifier of the webhook.
+     * @return A ListWebhookEventsResponseSuccess containing the webhook events.
+     * @throws ResendException If an error occurs while retrieving the events.
+     */
     public ListWebhookEventsResponseSuccess listEvents(String webhookId) throws ResendException {
         return listEvents(webhookId, null);
     }
 
+    /**
+     * Retrieves a paginated list of events delivered to a webhook.
+     *
+     * @param webhookId The unique identifier of the webhook.
+     * @param params The params used to customize the list.
+     * @return A ListWebhookEventsResponseSuccess containing the webhook events.
+     * @throws ResendException If an error occurs while retrieving the events.
+     */
     public ListWebhookEventsResponseSuccess listEvents(String webhookId, ListWebhookEventsParams params) throws ResendException {
         String query = params == null ? "" : params.toQueryString();
         AbstractHttpResponse<String> response = httpClient.perform("/webhooks/" + webhookId + "/events" + query, super.apiKey, HttpMethod.GET, null, MediaType.get("application/json"));
@@ -152,6 +167,14 @@ public final class Webhooks extends BaseService {
         return resendMapper.readValue(response.getBody(), ListWebhookEventsResponseSuccess.class);
     }
 
+    /**
+     * Retrieves a single event delivered to a webhook.
+     *
+     * @param webhookId The unique identifier of the webhook.
+     * @param eventId The unique identifier of the webhook event.
+     * @return The retrieved webhook event.
+     * @throws ResendException If an error occurs while retrieving the event.
+     */
     public GetWebhookEventResponseSuccess getEvent(String webhookId, String eventId) throws ResendException {
         AbstractHttpResponse<String> response = httpClient.perform("/webhooks/" + webhookId + "/events/" + eventId, super.apiKey, HttpMethod.GET, null, MediaType.get("application/json"));
 
@@ -162,10 +185,27 @@ public final class Webhooks extends BaseService {
         return resendMapper.readValue(response.getBody(), GetWebhookEventResponseSuccess.class);
     }
 
+    /**
+     * Retrieves the delivery attempts for a webhook event.
+     *
+     * @param webhookId The unique identifier of the webhook.
+     * @param eventId The unique identifier of the webhook event.
+     * @return A ListWebhookEventAttemptsResponseSuccess containing the delivery attempts.
+     * @throws ResendException If an error occurs while retrieving the attempts.
+     */
     public ListWebhookEventAttemptsResponseSuccess listEventAttempts(String webhookId, String eventId) throws ResendException {
         return listEventAttempts(webhookId, eventId, null);
     }
 
+    /**
+     * Retrieves a paginated list of delivery attempts for a webhook event.
+     *
+     * @param webhookId The unique identifier of the webhook.
+     * @param eventId The unique identifier of the webhook event.
+     * @param params The params used to customize the list.
+     * @return A ListWebhookEventAttemptsResponseSuccess containing the delivery attempts.
+     * @throws ResendException If an error occurs while retrieving the attempts.
+     */
     public ListWebhookEventAttemptsResponseSuccess listEventAttempts(String webhookId, String eventId, ListWebhookEventAttemptsParams params) throws ResendException {
         String query = params == null ? "" : params.toQueryString();
         AbstractHttpResponse<String> response = httpClient.perform("/webhooks/" + webhookId + "/events/" + eventId + "/attempts" + query, super.apiKey, HttpMethod.GET, null, MediaType.get("application/json"));

--- a/src/main/java/com/resend/services/webhooks/Webhooks.java
+++ b/src/main/java/com/resend/services/webhooks/Webhooks.java
@@ -14,6 +14,11 @@ import com.resend.services.webhooks.model.RemoveWebhookResponseSuccess;
 import com.resend.services.webhooks.model.UpdateWebhookOptions;
 import com.resend.services.webhooks.model.UpdateWebhookResponseSuccess;
 import com.resend.services.webhooks.model.GetWebhookResponseSuccess;
+import com.resend.services.webhooks.model.GetWebhookEventResponseSuccess;
+import com.resend.services.webhooks.model.ListWebhookEventAttemptsParams;
+import com.resend.services.webhooks.model.ListWebhookEventAttemptsResponseSuccess;
+import com.resend.services.webhooks.model.ListWebhookEventsParams;
+import com.resend.services.webhooks.model.ListWebhookEventsResponseSuccess;
 import com.resend.services.webhooks.model.VerifyWebhookOptions;
 import okhttp3.MediaType;
 import javax.crypto.Mac;
@@ -130,6 +135,46 @@ public final class Webhooks extends BaseService {
 
         String responseBody = response.getBody();
         return resendMapper.readValue(responseBody, ListWebhooksResponseSuccess.class);
+    }
+
+    public ListWebhookEventsResponseSuccess listEvents(String webhookId) throws ResendException {
+        return listEvents(webhookId, null);
+    }
+
+    public ListWebhookEventsResponseSuccess listEvents(String webhookId, ListWebhookEventsParams params) throws ResendException {
+        String query = params == null ? "" : params.toQueryString();
+        AbstractHttpResponse<String> response = httpClient.perform("/webhooks/" + webhookId + "/events" + query, super.apiKey, HttpMethod.GET, null, MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        return resendMapper.readValue(response.getBody(), ListWebhookEventsResponseSuccess.class);
+    }
+
+    public GetWebhookEventResponseSuccess getEvent(String webhookId, String eventId) throws ResendException {
+        AbstractHttpResponse<String> response = httpClient.perform("/webhooks/" + webhookId + "/events/" + eventId, super.apiKey, HttpMethod.GET, null, MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        return resendMapper.readValue(response.getBody(), GetWebhookEventResponseSuccess.class);
+    }
+
+    public ListWebhookEventAttemptsResponseSuccess listEventAttempts(String webhookId, String eventId) throws ResendException {
+        return listEventAttempts(webhookId, eventId, null);
+    }
+
+    public ListWebhookEventAttemptsResponseSuccess listEventAttempts(String webhookId, String eventId, ListWebhookEventAttemptsParams params) throws ResendException {
+        String query = params == null ? "" : params.toQueryString();
+        AbstractHttpResponse<String> response = httpClient.perform("/webhooks/" + webhookId + "/events/" + eventId + "/attempts" + query, super.apiKey, HttpMethod.GET, null, MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        return resendMapper.readValue(response.getBody(), ListWebhookEventAttemptsResponseSuccess.class);
     }
 
     /**

--- a/src/main/java/com/resend/services/webhooks/dto/WebhookEventAttemptDTO.java
+++ b/src/main/java/com/resend/services/webhooks/dto/WebhookEventAttemptDTO.java
@@ -2,6 +2,9 @@ package com.resend.services.webhooks.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Data Transfer Object for a webhook event delivery attempt.
+ */
 public class WebhookEventAttemptDTO {
     @JsonProperty("id")
     private String id;
@@ -15,18 +18,44 @@ public class WebhookEventAttemptDTO {
     @JsonProperty("sent_at")
     private String sentAt;
 
+    /**
+     * Constructs an empty webhook event attempt.
+     */
+    public WebhookEventAttemptDTO() {
+    }
+
+    /**
+     * Gets the attempt ID.
+     *
+     * @return The attempt ID.
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Gets the HTTP status code returned by the webhook endpoint.
+     *
+     * @return The HTTP status code.
+     */
     public Integer getHttpStatusCode() {
         return httpStatusCode;
     }
 
+    /**
+     * Gets the response body returned by the webhook endpoint.
+     *
+     * @return The response body.
+     */
     public String getResponse() {
         return response;
     }
 
+    /**
+     * Gets the timestamp when the attempt was sent.
+     *
+     * @return The sent timestamp.
+     */
     public String getSentAt() {
         return sentAt;
     }

--- a/src/main/java/com/resend/services/webhooks/dto/WebhookEventAttemptDTO.java
+++ b/src/main/java/com/resend/services/webhooks/dto/WebhookEventAttemptDTO.java
@@ -1,0 +1,33 @@
+package com.resend.services.webhooks.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class WebhookEventAttemptDTO {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("http_status_code")
+    private Integer httpStatusCode;
+
+    @JsonProperty("response")
+    private String response;
+
+    @JsonProperty("sent_at")
+    private String sentAt;
+
+    public String getId() {
+        return id;
+    }
+
+    public Integer getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    public String getResponse() {
+        return response;
+    }
+
+    public String getSentAt() {
+        return sentAt;
+    }
+}

--- a/src/main/java/com/resend/services/webhooks/dto/WebhookEventDTO.java
+++ b/src/main/java/com/resend/services/webhooks/dto/WebhookEventDTO.java
@@ -3,6 +3,9 @@ package com.resend.services.webhooks.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.resend.services.webhooks.model.WebhookEventStatus;
 
+/**
+ * Data Transfer Object for webhook event data in list responses.
+ */
 public class WebhookEventDTO {
     @JsonProperty("id")
     private String id;
@@ -16,18 +19,44 @@ public class WebhookEventDTO {
     @JsonProperty("status")
     private WebhookEventStatus status;
 
+    /**
+     * Constructs an empty webhook event.
+     */
+    public WebhookEventDTO() {
+    }
+
+    /**
+     * Gets the webhook event ID.
+     *
+     * @return The webhook event ID.
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Gets the event type.
+     *
+     * @return The event type.
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Gets the creation timestamp.
+     *
+     * @return The creation timestamp.
+     */
     public String getCreatedAt() {
         return createdAt;
     }
 
+    /**
+     * Gets the delivery status.
+     *
+     * @return The delivery status.
+     */
     public WebhookEventStatus getStatus() {
         return status;
     }

--- a/src/main/java/com/resend/services/webhooks/dto/WebhookEventDTO.java
+++ b/src/main/java/com/resend/services/webhooks/dto/WebhookEventDTO.java
@@ -1,0 +1,34 @@
+package com.resend.services.webhooks.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.resend.services.webhooks.model.WebhookEventStatus;
+
+public class WebhookEventDTO {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("created_at")
+    private String createdAt;
+
+    @JsonProperty("status")
+    private WebhookEventStatus status;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public WebhookEventStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/resend/services/webhooks/model/GetWebhookEventResponseSuccess.java
+++ b/src/main/java/com/resend/services/webhooks/model/GetWebhookEventResponseSuccess.java
@@ -1,0 +1,55 @@
+package com.resend.services.webhooks.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+public class GetWebhookEventResponseSuccess {
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("created_at")
+    private String createdAt;
+
+    @JsonProperty("status")
+    private WebhookEventStatus status;
+
+    @JsonProperty("next_attempt_at")
+    private String nextAttemptAt;
+
+    @JsonProperty("payload")
+    private Map<String, Object> payload;
+
+    public String getObject() {
+        return object;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public WebhookEventStatus getStatus() {
+        return status;
+    }
+
+    public String getNextAttemptAt() {
+        return nextAttemptAt;
+    }
+
+    public Map<String, Object> getPayload() {
+        return payload;
+    }
+}

--- a/src/main/java/com/resend/services/webhooks/model/GetWebhookEventResponseSuccess.java
+++ b/src/main/java/com/resend/services/webhooks/model/GetWebhookEventResponseSuccess.java
@@ -3,6 +3,9 @@ package com.resend.services.webhooks.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 
+/**
+ * Represents a webhook event.
+ */
 public class GetWebhookEventResponseSuccess {
     @JsonProperty("object")
     private String object;
@@ -25,30 +28,71 @@ public class GetWebhookEventResponseSuccess {
     @JsonProperty("payload")
     private Map<String, Object> payload;
 
+    /**
+     * Constructs an empty webhook event response.
+     */
+    public GetWebhookEventResponseSuccess() {
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
     public String getObject() {
         return object;
     }
 
+    /**
+     * Gets the webhook event ID.
+     *
+     * @return The webhook event ID.
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Gets the event type.
+     *
+     * @return The event type.
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Gets the creation timestamp.
+     *
+     * @return The creation timestamp.
+     */
     public String getCreatedAt() {
         return createdAt;
     }
 
+    /**
+     * Gets the delivery status.
+     *
+     * @return The delivery status.
+     */
     public WebhookEventStatus getStatus() {
         return status;
     }
 
+    /**
+     * Gets the timestamp when the next delivery attempt is scheduled.
+     *
+     * @return The next attempt timestamp, or null when no attempt is scheduled.
+     */
     public String getNextAttemptAt() {
         return nextAttemptAt;
     }
 
+    /**
+     * Gets the event payload sent to the webhook endpoint.
+     *
+     * @return The event payload.
+     */
     public Map<String, Object> getPayload() {
         return payload;
     }

--- a/src/main/java/com/resend/services/webhooks/model/ListWebhookEventAttemptsParams.java
+++ b/src/main/java/com/resend/services/webhooks/model/ListWebhookEventAttemptsParams.java
@@ -1,0 +1,49 @@
+package com.resend.services.webhooks.model;
+
+import com.resend.core.helper.URLHelper;
+import com.resend.core.net.ListParams;
+
+public class ListWebhookEventAttemptsParams {
+    private final Integer limit;
+    private final String after;
+
+    public ListWebhookEventAttemptsParams(Builder builder) {
+        this.limit = builder.limit;
+        this.after = builder.after;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public String getAfter() {
+        return after;
+    }
+
+    public String toQueryString() {
+        return URLHelper.parse(ListParams.builder().limit(limit).after(after).build());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Integer limit;
+        private String after;
+
+        public Builder limit(Integer limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public Builder after(String after) {
+            this.after = after;
+            return this;
+        }
+
+        public ListWebhookEventAttemptsParams build() {
+            return new ListWebhookEventAttemptsParams(this);
+        }
+    }
+}

--- a/src/main/java/com/resend/services/webhooks/model/ListWebhookEventAttemptsParams.java
+++ b/src/main/java/com/resend/services/webhooks/model/ListWebhookEventAttemptsParams.java
@@ -3,45 +3,99 @@ package com.resend.services.webhooks.model;
 import com.resend.core.helper.URLHelper;
 import com.resend.core.net.ListParams;
 
+/**
+ * Represents the pagination parameters for listing webhook event attempts.
+ */
 public class ListWebhookEventAttemptsParams {
     private final Integer limit;
     private final String after;
 
+    /**
+     * Constructs the parameters from a builder.
+     *
+     * @param builder The builder containing the pagination parameters.
+     */
     public ListWebhookEventAttemptsParams(Builder builder) {
         this.limit = builder.limit;
         this.after = builder.after;
     }
 
+    /**
+     * Gets the maximum number of attempts to return.
+     *
+     * @return The result limit.
+     */
     public Integer getLimit() {
         return limit;
     }
 
+    /**
+     * Gets the attempt ID after which to retrieve results.
+     *
+     * @return The pagination cursor.
+     */
     public String getAfter() {
         return after;
     }
 
+    /**
+     * Converts the parameters to a URL query string.
+     *
+     * @return The URL query string.
+     */
     public String toQueryString() {
         return URLHelper.parse(ListParams.builder().limit(limit).after(after).build());
     }
 
+    /**
+     * Creates a new parameters builder.
+     *
+     * @return A new builder.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Builds parameters for listing webhook event attempts.
+     */
     public static class Builder {
         private Integer limit;
         private String after;
 
+        /**
+         * Constructs an empty webhook event attempt list parameters builder.
+         */
+        public Builder() {
+        }
+
+        /**
+         * Sets the maximum number of attempts to return.
+         *
+         * @param limit The result limit.
+         * @return This builder.
+         */
         public Builder limit(Integer limit) {
             this.limit = limit;
             return this;
         }
 
+        /**
+         * Sets the attempt ID after which to retrieve results.
+         *
+         * @param after The pagination cursor.
+         * @return This builder.
+         */
         public Builder after(String after) {
             this.after = after;
             return this;
         }
 
+        /**
+         * Builds the webhook event attempt list parameters.
+         *
+         * @return The configured parameters.
+         */
         public ListWebhookEventAttemptsParams build() {
             return new ListWebhookEventAttemptsParams(this);
         }

--- a/src/main/java/com/resend/services/webhooks/model/ListWebhookEventAttemptsResponseSuccess.java
+++ b/src/main/java/com/resend/services/webhooks/model/ListWebhookEventAttemptsResponseSuccess.java
@@ -1,0 +1,28 @@
+package com.resend.services.webhooks.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.resend.services.webhooks.dto.WebhookEventAttemptDTO;
+import java.util.List;
+
+public class ListWebhookEventAttemptsResponseSuccess {
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("has_more")
+    private Boolean hasMore;
+
+    @JsonProperty("data")
+    private List<WebhookEventAttemptDTO> data;
+
+    public String getObject() {
+        return object;
+    }
+
+    public Boolean hasMore() {
+        return hasMore;
+    }
+
+    public List<WebhookEventAttemptDTO> getData() {
+        return data;
+    }
+}

--- a/src/main/java/com/resend/services/webhooks/model/ListWebhookEventAttemptsResponseSuccess.java
+++ b/src/main/java/com/resend/services/webhooks/model/ListWebhookEventAttemptsResponseSuccess.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.resend.services.webhooks.dto.WebhookEventAttemptDTO;
 import java.util.List;
 
+/**
+ * Represents a successful response from listing webhook event attempts.
+ */
 public class ListWebhookEventAttemptsResponseSuccess {
     @JsonProperty("object")
     private String object;
@@ -14,14 +17,35 @@ public class ListWebhookEventAttemptsResponseSuccess {
     @JsonProperty("data")
     private List<WebhookEventAttemptDTO> data;
 
+    /**
+     * Constructs an empty webhook event attempt list response.
+     */
+    public ListWebhookEventAttemptsResponseSuccess() {
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
     public String getObject() {
         return object;
     }
 
+    /**
+     * Indicates whether more attempts are available for pagination.
+     *
+     * @return True if more attempts are available, false otherwise.
+     */
     public Boolean hasMore() {
         return hasMore;
     }
 
+    /**
+     * Gets the webhook event attempts.
+     *
+     * @return The list of delivery attempts.
+     */
     public List<WebhookEventAttemptDTO> getData() {
         return data;
     }

--- a/src/main/java/com/resend/services/webhooks/model/ListWebhookEventsParams.java
+++ b/src/main/java/com/resend/services/webhooks/model/ListWebhookEventsParams.java
@@ -3,45 +3,99 @@ package com.resend.services.webhooks.model;
 import com.resend.core.helper.URLHelper;
 import com.resend.core.net.ListParams;
 
+/**
+ * Represents the pagination parameters for listing webhook events.
+ */
 public class ListWebhookEventsParams {
     private final Integer limit;
     private final String after;
 
+    /**
+     * Constructs the parameters from a builder.
+     *
+     * @param builder The builder containing the pagination parameters.
+     */
     public ListWebhookEventsParams(Builder builder) {
         this.limit = builder.limit;
         this.after = builder.after;
     }
 
+    /**
+     * Gets the maximum number of events to return.
+     *
+     * @return The result limit.
+     */
     public Integer getLimit() {
         return limit;
     }
 
+    /**
+     * Gets the event ID after which to retrieve results.
+     *
+     * @return The pagination cursor.
+     */
     public String getAfter() {
         return after;
     }
 
+    /**
+     * Converts the parameters to a URL query string.
+     *
+     * @return The URL query string.
+     */
     public String toQueryString() {
         return URLHelper.parse(ListParams.builder().limit(limit).after(after).build());
     }
 
+    /**
+     * Creates a new parameters builder.
+     *
+     * @return A new builder.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Builds parameters for listing webhook events.
+     */
     public static class Builder {
         private Integer limit;
         private String after;
 
+        /**
+         * Constructs an empty webhook event list parameters builder.
+         */
+        public Builder() {
+        }
+
+        /**
+         * Sets the maximum number of events to return.
+         *
+         * @param limit The result limit.
+         * @return This builder.
+         */
         public Builder limit(Integer limit) {
             this.limit = limit;
             return this;
         }
 
+        /**
+         * Sets the event ID after which to retrieve results.
+         *
+         * @param after The pagination cursor.
+         * @return This builder.
+         */
         public Builder after(String after) {
             this.after = after;
             return this;
         }
 
+        /**
+         * Builds the webhook event list parameters.
+         *
+         * @return The configured parameters.
+         */
         public ListWebhookEventsParams build() {
             return new ListWebhookEventsParams(this);
         }

--- a/src/main/java/com/resend/services/webhooks/model/ListWebhookEventsParams.java
+++ b/src/main/java/com/resend/services/webhooks/model/ListWebhookEventsParams.java
@@ -1,0 +1,49 @@
+package com.resend.services.webhooks.model;
+
+import com.resend.core.helper.URLHelper;
+import com.resend.core.net.ListParams;
+
+public class ListWebhookEventsParams {
+    private final Integer limit;
+    private final String after;
+
+    public ListWebhookEventsParams(Builder builder) {
+        this.limit = builder.limit;
+        this.after = builder.after;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public String getAfter() {
+        return after;
+    }
+
+    public String toQueryString() {
+        return URLHelper.parse(ListParams.builder().limit(limit).after(after).build());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Integer limit;
+        private String after;
+
+        public Builder limit(Integer limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public Builder after(String after) {
+            this.after = after;
+            return this;
+        }
+
+        public ListWebhookEventsParams build() {
+            return new ListWebhookEventsParams(this);
+        }
+    }
+}

--- a/src/main/java/com/resend/services/webhooks/model/ListWebhookEventsResponseSuccess.java
+++ b/src/main/java/com/resend/services/webhooks/model/ListWebhookEventsResponseSuccess.java
@@ -1,0 +1,28 @@
+package com.resend.services.webhooks.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.resend.services.webhooks.dto.WebhookEventDTO;
+import java.util.List;
+
+public class ListWebhookEventsResponseSuccess {
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("has_more")
+    private Boolean hasMore;
+
+    @JsonProperty("data")
+    private List<WebhookEventDTO> data;
+
+    public String getObject() {
+        return object;
+    }
+
+    public Boolean hasMore() {
+        return hasMore;
+    }
+
+    public List<WebhookEventDTO> getData() {
+        return data;
+    }
+}

--- a/src/main/java/com/resend/services/webhooks/model/ListWebhookEventsResponseSuccess.java
+++ b/src/main/java/com/resend/services/webhooks/model/ListWebhookEventsResponseSuccess.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.resend.services.webhooks.dto.WebhookEventDTO;
 import java.util.List;
 
+/**
+ * Represents a successful response from listing webhook events.
+ */
 public class ListWebhookEventsResponseSuccess {
     @JsonProperty("object")
     private String object;
@@ -14,14 +17,35 @@ public class ListWebhookEventsResponseSuccess {
     @JsonProperty("data")
     private List<WebhookEventDTO> data;
 
+    /**
+     * Constructs an empty webhook event list response.
+     */
+    public ListWebhookEventsResponseSuccess() {
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
     public String getObject() {
         return object;
     }
 
+    /**
+     * Indicates whether more events are available for pagination.
+     *
+     * @return True if more events are available, false otherwise.
+     */
     public Boolean hasMore() {
         return hasMore;
     }
 
+    /**
+     * Gets the webhook events.
+     *
+     * @return The list of webhook events.
+     */
     public List<WebhookEventDTO> getData() {
         return data;
     }

--- a/src/main/java/com/resend/services/webhooks/model/WebhookEventStatus.java
+++ b/src/main/java/com/resend/services/webhooks/model/WebhookEventStatus.java
@@ -1,0 +1,32 @@
+package com.resend.services.webhooks.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum WebhookEventStatus {
+    PENDING("pending"),
+    ATTEMPTING("attempting"),
+    SUCCESS("success"),
+    FAILED("failed");
+
+    private final String value;
+
+    WebhookEventStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static WebhookEventStatus fromValue(String value) {
+        for (WebhookEventStatus status : WebhookEventStatus.values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown status: " + value);
+    }
+}

--- a/src/main/java/com/resend/services/webhooks/model/WebhookEventStatus.java
+++ b/src/main/java/com/resend/services/webhooks/model/WebhookEventStatus.java
@@ -3,10 +3,17 @@ package com.resend.services.webhooks.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * Represents the delivery status of a webhook event.
+ */
 public enum WebhookEventStatus {
+    /** The event is waiting for a delivery attempt. */
     PENDING("pending"),
+    /** The event is currently being delivered. */
     ATTEMPTING("attempting"),
+    /** The event was delivered successfully. */
     SUCCESS("success"),
+    /** The event could not be delivered. */
     FAILED("failed");
 
     private final String value;
@@ -15,11 +22,23 @@ public enum WebhookEventStatus {
         this.value = value;
     }
 
+    /**
+     * Gets the API representation of the status.
+     *
+     * @return The status value.
+     */
     @JsonValue
     public String getValue() {
         return value;
     }
 
+    /**
+     * Converts an API status value to a WebhookEventStatus.
+     *
+     * @param value The API status value.
+     * @return The matching webhook event status.
+     * @throws IllegalArgumentException If the value is not a known status.
+     */
     @JsonCreator
     public static WebhookEventStatus fromValue(String value) {
         for (WebhookEventStatus status : WebhookEventStatus.values()) {

--- a/src/test/java/com/resend/services/webhooks/WebhooksTest.java
+++ b/src/test/java/com/resend/services/webhooks/WebhooksTest.java
@@ -49,6 +49,17 @@ public class WebhooksTest {
     private static final String REMOVE_WEBHOOK_JSON =
             "{\"object\":\"webhook\",\"id\":\"" + WEBHOOK_ID + "\",\"deleted\":true}";
 
+    private static final String EVENT_ID = "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2";
+
+    private static final String LIST_WEBHOOK_EVENTS_JSON =
+            "{\"object\":\"list\",\"has_more\":true,\"data\":[{\"id\":\"" + EVENT_ID + "\",\"type\":\"email.sent\",\"created_at\":\"2026-08-22T15:28:00.000Z\",\"status\":\"success\"}]}";
+
+    private static final String GET_WEBHOOK_EVENT_JSON =
+            "{\"object\":\"webhook_event\",\"id\":\"" + EVENT_ID + "\",\"type\":\"email.sent\",\"created_at\":\"2026-08-22T15:28:00.000Z\",\"status\":\"success\",\"next_attempt_at\":null,\"payload\":{\"type\":\"email.sent\",\"data\":{\"email_id\":\"email_123\"}}}";
+
+    private static final String LIST_WEBHOOK_EVENT_ATTEMPTS_JSON =
+            "{\"object\":\"list\",\"has_more\":false,\"data\":[{\"id\":\"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\"http_status_code\":200,\"response\":\"{\\\"ok\\\":true}\",\"sent_at\":\"2026-08-22T15:33:12.000Z\"}]}";
+
     @Mock
     private IHttpClient httpClient;
 
@@ -152,6 +163,61 @@ public class WebhooksTest {
         assertNotNull(response);
         assertEquals(1, response.getData().size());
         assertTrue(response.hasMore());
+    }
+
+    @Test
+    public void testListWebhookEventsWithPagination_Success() throws ResendException {
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, LIST_WEBHOOK_EVENTS_JSON, true);
+        ListWebhookEventsParams params = ListWebhookEventsParams.builder().limit(10).after("msg cursor").build();
+
+        when(httpClient.perform(eq("/webhooks/" + WEBHOOK_ID + "/events?limit=10&after=msg+cursor"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        ListWebhookEventsResponseSuccess response = webhooks.listEvents(WEBHOOK_ID, params);
+
+        assertEquals("list", response.getObject());
+        assertTrue(response.hasMore());
+        assertEquals(EVENT_ID, response.getData().get(0).getId());
+        assertEquals("email.sent", response.getData().get(0).getType());
+        assertEquals("2026-08-22T15:28:00.000Z", response.getData().get(0).getCreatedAt());
+        assertEquals(WebhookEventStatus.SUCCESS, response.getData().get(0).getStatus());
+    }
+
+    @Test
+    public void testGetWebhookEvent_Success() throws ResendException {
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, GET_WEBHOOK_EVENT_JSON, true);
+
+        when(httpClient.perform(eq("/webhooks/" + WEBHOOK_ID + "/events/" + EVENT_ID), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        GetWebhookEventResponseSuccess response = webhooks.getEvent(WEBHOOK_ID, EVENT_ID);
+
+        assertEquals("webhook_event", response.getObject());
+        assertEquals(EVENT_ID, response.getId());
+        assertEquals("email.sent", response.getType());
+        assertEquals("2026-08-22T15:28:00.000Z", response.getCreatedAt());
+        assertEquals(WebhookEventStatus.SUCCESS, response.getStatus());
+        assertNull(response.getNextAttemptAt());
+        assertEquals("email.sent", response.getPayload().get("type"));
+        assertTrue(response.getPayload().get("data") instanceof java.util.Map);
+    }
+
+    @Test
+    public void testListWebhookEventAttemptsWithPagination_Success() throws ResendException {
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, LIST_WEBHOOK_EVENT_ATTEMPTS_JSON, true);
+        ListWebhookEventAttemptsParams params = ListWebhookEventAttemptsParams.builder().limit(5).after("atmpt cursor").build();
+
+        when(httpClient.perform(eq("/webhooks/" + WEBHOOK_ID + "/events/" + EVENT_ID + "/attempts?limit=5&after=atmpt+cursor"), anyString(), eq(HttpMethod.GET), isNull(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        ListWebhookEventAttemptsResponseSuccess response = webhooks.listEventAttempts(WEBHOOK_ID, EVENT_ID, params);
+
+        assertEquals("list", response.getObject());
+        assertFalse(response.hasMore());
+        assertEquals("atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2", response.getData().get(0).getId());
+        assertEquals(200, response.getData().get(0).getHttpStatusCode());
+        assertEquals("{\"ok\":true}", response.getData().get(0).getResponse());
+        assertEquals("2026-08-22T15:33:12.000Z", response.getData().get(0).getSentAt());
     }
 
     @Test


### PR DESCRIPTION
Adds webhook event listing, retrieval, and delivery-attempt listing with endpoint-specific pagination and typed response models.

Linear: https://linear.app/resend/issue/DEV-1929

Checks: clean Gradle test suite on JDK 21 and live Keychain-authenticated API calls through all three methods.