### PR TITLE
feat(segments): add update endpoint

### DIFF
--- a/src/main/java/com/resend/services/segments/Segments.java
+++ b/src/main/java/com/resend/services/segments/Segments.java
@@ -105,6 +105,27 @@ public class Segments extends BaseService {
     }
 
     /**
+     * Updates a segment by its unique identifier.
+     *
+     * @param id The unique identifier of the segment.
+     * @param updateSegmentOptions The new data for the segment.
+     * @return The response indicating the status of the segment update.
+     * @throws ResendException If an error occurs while updating the segment.
+     */
+    public UpdateSegmentResponseSuccess update(String id, UpdateSegmentOptions updateSegmentOptions) throws ResendException {
+        String payload = super.resendMapper.writeValue(updateSegmentOptions);
+        AbstractHttpResponse<String> response = this.httpClient.perform("/segments/" + id, super.apiKey, HttpMethod.PATCH, payload, MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+
+        return resendMapper.readValue(responseBody, UpdateSegmentResponseSuccess.class);
+    }
+
+    /**
      * Deletes a segment based on the provided segment ID.
      *
      * @param id The unique identifier of the segment to delete.

--- a/src/main/java/com/resend/services/segments/model/UpdateSegmentOptions.java
+++ b/src/main/java/com/resend/services/segments/model/UpdateSegmentOptions.java
@@ -1,0 +1,75 @@
+package com.resend.services.segments.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a request to update a segment.
+ */
+public class UpdateSegmentOptions {
+
+    /**
+     * The segment name.
+     */
+    @JsonProperty("name")
+    private final String name;
+
+    /**
+     * Private constructor used by the Builder.
+     *
+     * @param builder The builder instance.
+     */
+    private UpdateSegmentOptions(Builder builder) {
+        this.name = builder.name;
+    }
+
+    /**
+     * Retrieves the name of the segment.
+     *
+     * @return The segment name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Creates a new builder instance to construct UpdateSegmentOptions.
+     *
+     * @return A new builder instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing UpdateSegmentOptions instances.
+     */
+    public static class Builder {
+        /**
+         * Creates a new Builder instance.
+         */
+        public Builder() {
+        }
+
+        private String name;
+
+        /**
+         * Set the segment name.
+         *
+         * @param name The segment name.
+         * @return This builder instance for method chaining.
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Builds and returns a {@code UpdateSegmentOptions} based on the configured properties.
+         *
+         * @return A {@code UpdateSegmentOptions} instance.
+         */
+        public UpdateSegmentOptions build() {
+            return new UpdateSegmentOptions(this);
+        }
+    }
+}

--- a/src/main/java/com/resend/services/segments/model/UpdateSegmentOptions.java
+++ b/src/main/java/com/resend/services/segments/model/UpdateSegmentOptions.java
@@ -67,8 +67,12 @@ public class UpdateSegmentOptions {
          * Builds and returns a {@code UpdateSegmentOptions} based on the configured properties.
          *
          * @return A {@code UpdateSegmentOptions} instance.
+         * @throws IllegalArgumentException if {@code name} is null or blank.
          */
         public UpdateSegmentOptions build() {
+            if (name == null || name.trim().isEmpty()) {
+                throw new IllegalArgumentException("name must not be null or blank");
+            }
             return new UpdateSegmentOptions(this);
         }
     }

--- a/src/main/java/com/resend/services/segments/model/UpdateSegmentOptions.java
+++ b/src/main/java/com/resend/services/segments/model/UpdateSegmentOptions.java
@@ -70,10 +70,20 @@ public class UpdateSegmentOptions {
          * @throws IllegalArgumentException if {@code name} is null or blank.
          */
         public UpdateSegmentOptions build() {
-            if (name == null || name.trim().isEmpty()) {
+            if (name == null || isBlank(name)) {
                 throw new IllegalArgumentException("name must not be null or blank");
             }
             return new UpdateSegmentOptions(this);
+        }
+
+        private static boolean isBlank(String value) {
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (!Character.isWhitespace(c) && !Character.isSpaceChar(c)) {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }

--- a/src/main/java/com/resend/services/segments/model/UpdateSegmentResponseSuccess.java
+++ b/src/main/java/com/resend/services/segments/model/UpdateSegmentResponseSuccess.java
@@ -1,0 +1,41 @@
+package com.resend.services.segments.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a successful response for updating a segment.
+ * Extends the BaseSegment class.
+ */
+public class UpdateSegmentResponseSuccess extends BaseSegment {
+
+    @JsonProperty("object")
+    private String object;
+
+    /**
+     * Default constructor
+     */
+    public UpdateSegmentResponseSuccess() {
+
+    }
+
+    /**
+     * Constructs a successful response for updating a segment.
+     *
+     * @param id        The ID of the segment.
+     * @param name      The name of the segment.
+     * @param object    The object of the segment.
+     */
+    public UpdateSegmentResponseSuccess(String id, String name, String object) {
+        super(id, name);
+        this.object = object;
+    }
+
+    /**
+     * Get the object.
+     *
+     * @return The type of the data.
+     */
+    public String getObject() {
+        return object;
+    }
+}

--- a/src/main/java/com/resend/services/segments/model/UpdateSegmentResponseSuccess.java
+++ b/src/main/java/com/resend/services/segments/model/UpdateSegmentResponseSuccess.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Represents a successful response for updating a segment.
- * Extends the BaseSegment class.
  */
-public class UpdateSegmentResponseSuccess extends BaseSegment {
+public class UpdateSegmentResponseSuccess {
+
+    @JsonProperty("id")
+    private String id;
 
     @JsonProperty("object")
     private String object;
@@ -22,12 +24,20 @@ public class UpdateSegmentResponseSuccess extends BaseSegment {
      * Constructs a successful response for updating a segment.
      *
      * @param id        The ID of the segment.
-     * @param name      The name of the segment.
      * @param object    The object of the segment.
      */
-    public UpdateSegmentResponseSuccess(String id, String name, String object) {
-        super(id, name);
+    public UpdateSegmentResponseSuccess(String id, String object) {
+        this.id = id;
         this.object = object;
+    }
+
+    /**
+     * Get the ID.
+     *
+     * @return The ID of the segment.
+     */
+    public String getId() {
+        return id;
     }
 
     /**

--- a/src/test/java/com/resend/services/segments/SegmentsTest.java
+++ b/src/test/java/com/resend/services/segments/SegmentsTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 public class SegmentsTest {
 
     private static final String CREATE_RESPONSE_JSON = "{\"id\":\"123\",\"name\":\"seg\",\"object\":\"audience\"}";
-    private static final String UPDATE_RESPONSE_JSON = "{\"id\":\"123\",\"name\":\"updated-seg\",\"object\":\"segment\"}";
+    private static final String UPDATE_RESPONSE_JSON = "{\"id\":\"123\",\"object\":\"segment\"}";
     private static final String REMOVE_RESPONSE_JSON = "{\"id\":\"123\",\"object\":\"audience\",\"deleted\":true}";
     private static final String GET_RESPONSE_JSON =
             "{\"id\":\"123\",\"name\":\"seg\",\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"object\":\"audience\"}";
@@ -84,7 +84,6 @@ public class SegmentsTest {
 
         assertNotNull(updated);
         assertEquals("123", updated.getId());
-        assertEquals("updated-seg", updated.getName());
         assertEquals("segment", updated.getObject());
     }
 

--- a/src/test/java/com/resend/services/segments/SegmentsTest.java
+++ b/src/test/java/com/resend/services/segments/SegmentsTest.java
@@ -111,6 +111,11 @@ public class SegmentsTest {
     }
 
     @Test
+    public void testUpdateSegmentOptions_Builder_ThrowsWhenNameUnicodeWhitespace() {
+        assertThrows(IllegalArgumentException.class, () -> UpdateSegmentOptions.builder().name("\u2003").build());
+    }
+
+    @Test
     public void testDeleteSegment_Success() throws ResendException {
         String segmentId = "123";
         AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, REMOVE_RESPONSE_JSON, true);

--- a/src/test/java/com/resend/services/segments/SegmentsTest.java
+++ b/src/test/java/com/resend/services/segments/SegmentsTest.java
@@ -102,6 +102,16 @@ public class SegmentsTest {
     }
 
     @Test
+    public void testUpdateSegmentOptions_Builder_ThrowsWhenNameMissing() {
+        assertThrows(IllegalArgumentException.class, () -> UpdateSegmentOptions.builder().build());
+    }
+
+    @Test
+    public void testUpdateSegmentOptions_Builder_ThrowsWhenNameBlank() {
+        assertThrows(IllegalArgumentException.class, () -> UpdateSegmentOptions.builder().name("  ").build());
+    }
+
+    @Test
     public void testDeleteSegment_Success() throws ResendException {
         String segmentId = "123";
         AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, REMOVE_RESPONSE_JSON, true);

--- a/src/test/java/com/resend/services/segments/SegmentsTest.java
+++ b/src/test/java/com/resend/services/segments/SegmentsTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 public class SegmentsTest {
 
     private static final String CREATE_RESPONSE_JSON = "{\"id\":\"123\",\"name\":\"seg\",\"object\":\"audience\"}";
+    private static final String UPDATE_RESPONSE_JSON = "{\"id\":\"123\",\"name\":\"updated-seg\",\"object\":\"segment\"}";
     private static final String REMOVE_RESPONSE_JSON = "{\"id\":\"123\",\"object\":\"audience\",\"deleted\":true}";
     private static final String GET_RESPONSE_JSON =
             "{\"id\":\"123\",\"name\":\"seg\",\"created_at\":\"2023-04-08 00:11:13.110779+00\",\"object\":\"audience\"}";
@@ -68,6 +69,36 @@ public class SegmentsTest {
 
         ResendException ex = assertThrows(ResendException.class, () -> segments.create(param));
         assertEquals(422, (int) ex.getStatusCode());
+    }
+
+    @Test
+    public void testUpdateSegment_Success() throws ResendException {
+        String segmentId = "123";
+        UpdateSegmentOptions param = SegmentsUtil.updateSegmentRequest();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, UPDATE_RESPONSE_JSON, true);
+
+        when(httpClient.perform(eq("/segments/" + segmentId), anyString(), eq(HttpMethod.PATCH), anyString(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        UpdateSegmentResponseSuccess updated = segments.update(segmentId, param);
+
+        assertNotNull(updated);
+        assertEquals("123", updated.getId());
+        assertEquals("updated-seg", updated.getName());
+        assertEquals("segment", updated.getObject());
+    }
+
+    @Test
+    public void testUpdateSegment_ApiError_ThrowsResendException() throws ResendException {
+        String segmentId = "123";
+        UpdateSegmentOptions param = SegmentsUtil.updateSegmentRequest();
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(404, "{\"name\":\"not_found\",\"message\":\"Segment not found\"}", false);
+
+        when(httpClient.perform(eq("/segments/" + segmentId), anyString(), eq(HttpMethod.PATCH), anyString(), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        ResendException ex = assertThrows(ResendException.class, () -> segments.update(segmentId, param));
+        assertEquals(404, (int) ex.getStatusCode());
     }
 
     @Test

--- a/src/test/java/com/resend/services/util/SegmentsUtil.java
+++ b/src/test/java/com/resend/services/util/SegmentsUtil.java
@@ -22,7 +22,7 @@ public class SegmentsUtil {
     }
 
     public static UpdateSegmentResponseSuccess updateSegmentResponse() {
-        return new UpdateSegmentResponseSuccess("123", "updated-seg", "segment");
+        return new UpdateSegmentResponseSuccess("123", "segment");
     }
 
     public static RemoveSegmentResponseSuccess removeSegmentsResponseSuccess() {

--- a/src/test/java/com/resend/services/util/SegmentsUtil.java
+++ b/src/test/java/com/resend/services/util/SegmentsUtil.java
@@ -15,6 +15,16 @@ public class SegmentsUtil {
         return new CreateSegmentResponseSuccess("123", "seg", "audience");
     }
 
+    public static UpdateSegmentOptions updateSegmentRequest() {
+        return UpdateSegmentOptions.builder()
+                .name("updated-seg")
+                .build();
+    }
+
+    public static UpdateSegmentResponseSuccess updateSegmentResponse() {
+        return new UpdateSegmentResponseSuccess("123", "updated-seg", "segment");
+    }
+
     public static RemoveSegmentResponseSuccess removeSegmentsResponseSuccess() {
         return new RemoveSegmentResponseSuccess("123", "audience", true);
     }


### PR DESCRIPTION
Adds `Segments.update(id, UpdateSegmentOptions)`, mapping to `PATCH /segments/:id`, mirroring the existing `Topics.update()` rename-style PATCH.

```java
Resend resend = new Resend("re_xxxxxxxxx");

UpdateSegmentOptions params = UpdateSegmentOptions.builder()
    .name("New segment name")
    .build();

UpdateSegmentResponseSuccess data = resend.segments().update("78261eea-8f8b-4381-83c6-79fa7120f1cf", params);
```

**Params**
- `name` (string, required)

**Response**
```json
{
  "object": "segment",
  "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf"
}
```