### PR TITLE
feat(webhooks): add event replay endpoint

### DIFF
--- a/src/main/java/com/resend/services/webhooks/Webhooks.java
+++ b/src/main/java/com/resend/services/webhooks/Webhooks.java
@@ -19,6 +19,7 @@ import com.resend.services.webhooks.model.ListWebhookEventAttemptsParams;
 import com.resend.services.webhooks.model.ListWebhookEventAttemptsResponseSuccess;
 import com.resend.services.webhooks.model.ListWebhookEventsParams;
 import com.resend.services.webhooks.model.ListWebhookEventsResponseSuccess;
+import com.resend.services.webhooks.model.ReplayWebhookEventResponseSuccess;
 import com.resend.services.webhooks.model.VerifyWebhookOptions;
 import okhttp3.MediaType;
 import javax.crypto.Mac;
@@ -183,6 +184,24 @@ public final class Webhooks extends BaseService {
         }
 
         return resendMapper.readValue(response.getBody(), GetWebhookEventResponseSuccess.class);
+    }
+
+    /**
+     * Queues one more delivery of a webhook event to its webhook.
+     *
+     * @param webhookId The unique identifier of the webhook.
+     * @param eventId The unique identifier of the webhook event.
+     * @return A ReplayWebhookEventResponseSuccess containing the replayed event ID.
+     * @throws ResendException If an error occurs while replaying the event.
+     */
+    public ReplayWebhookEventResponseSuccess replayEvent(String webhookId, String eventId) throws ResendException {
+        AbstractHttpResponse<String> response = httpClient.perform("/webhooks/" + webhookId + "/events/" + eventId + "/replay", super.apiKey, HttpMethod.POST, "", MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        return resendMapper.readValue(response.getBody(), ReplayWebhookEventResponseSuccess.class);
     }
 
     /**

--- a/src/main/java/com/resend/services/webhooks/model/ReplayWebhookEventResponseSuccess.java
+++ b/src/main/java/com/resend/services/webhooks/model/ReplayWebhookEventResponseSuccess.java
@@ -1,0 +1,38 @@
+package com.resend.services.webhooks.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a successful response from replaying a webhook event.
+ */
+public class ReplayWebhookEventResponseSuccess {
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("id")
+    private String id;
+
+    /**
+     * Constructs an empty webhook event replay response.
+     */
+    public ReplayWebhookEventResponseSuccess() {
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Gets the webhook event ID.
+     *
+     * @return The webhook event ID.
+     */
+    public String getId() {
+        return id;
+    }
+}

--- a/src/test/java/com/resend/services/webhooks/WebhooksTest.java
+++ b/src/test/java/com/resend/services/webhooks/WebhooksTest.java
@@ -57,6 +57,9 @@ public class WebhooksTest {
     private static final String GET_WEBHOOK_EVENT_JSON =
             "{\"object\":\"webhook_event\",\"id\":\"" + EVENT_ID + "\",\"type\":\"email.sent\",\"created_at\":\"2026-08-22T15:28:00.000Z\",\"status\":\"success\",\"next_attempt_at\":null,\"payload\":{\"type\":\"email.sent\",\"data\":{\"email_id\":\"email_123\"}}}";
 
+    private static final String REPLAY_WEBHOOK_EVENT_JSON =
+            "{\"object\":\"webhook_event\",\"id\":\"" + EVENT_ID + "\"}";
+
     private static final String LIST_WEBHOOK_EVENT_ATTEMPTS_JSON =
             "{\"object\":\"list\",\"has_more\":false,\"data\":[{\"id\":\"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\"http_status_code\":200,\"response\":\"{\\\"ok\\\":true}\",\"sent_at\":\"2026-08-22T15:33:12.000Z\"}]}";
 
@@ -200,6 +203,19 @@ public class WebhooksTest {
         assertNull(response.getNextAttemptAt());
         assertEquals("email.sent", response.getPayload().get("type"));
         assertTrue(response.getPayload().get("data") instanceof java.util.Map);
+    }
+
+    @Test
+    public void testReplayWebhookEvent_Success() throws ResendException {
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, REPLAY_WEBHOOK_EVENT_JSON, true);
+
+        when(httpClient.perform(eq("/webhooks/" + WEBHOOK_ID + "/events/" + EVENT_ID + "/replay"), anyString(), eq(HttpMethod.POST), eq(""), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        ReplayWebhookEventResponseSuccess response = webhooks.replayEvent(WEBHOOK_ID, EVENT_ID);
+
+        assertEquals("webhook_event", response.getObject());
+        assertEquals(EVENT_ID, response.getId());
     }
 
     @Test


### PR DESCRIPTION
Adds `Webhooks.replayEvent(String webhookId, String eventId)` for `POST /webhooks/{webhook_id}/events/{event_id}/replay`, which queues one more delivery of a webhook event to its webhook. Returns `ReplayWebhookEventResponseSuccess` (`object`, `id`). Placed next to `getEvent`, following #136.

Offered for the maintainer's review.

```java
Resend resend = new Resend("re_xxxxxxxxx");

ReplayWebhookEventResponseSuccess replayed = resend.webhooks().replayEvent(
        "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
        "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2");

System.out.println(replayed.getId());
```

Spec: https://github.com/resend/resend-openapi/pull/112
API: https://github.com/resend/resend-monorepo/pull/9535
Docs: https://resend.com/docs/api-reference/webhooks/replay-event

Checks: `./gradlew test` passes on JDK 21 (CI uses temurin 11; JDK 11 is not installed locally). No live call: replay is a write endpoint.

Not done: no version bump (separate chore PR, as with #136).

Part of DEV-2005.

Linear: https://linear.app/resend/issue/DEV-2015


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Webhooks.replayEvent(webhookId, eventId)` to queue one more delivery of a webhook event via `POST /webhooks/{webhook_id}/events/{event_id}/replay`. Part of DEV-2005.

**New Features**
- Returns a `ReplayWebhookEventResponseSuccess` model with `object` and `id` fields.
- Unit test covers the successful replay path.
- No version bump; handled in a separate chore.

<sup>Written for commit adcbc7b6f5cf8f611e2b3ed3498b10fddab7938c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-java/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

