### PR TITLE
feat(webhooks): add signing secret rotation endpoint

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.resend
-VERSION_NAME=4.23.0
+VERSION_NAME=4.24.0
 
 POM_URL=https://github.com/resendlabs/resend-java
 POM_SCM_URL=https://github.com/resendlabs/resend-java.git

--- a/src/main/java/com/resend/services/webhooks/Webhooks.java
+++ b/src/main/java/com/resend/services/webhooks/Webhooks.java
@@ -206,7 +206,7 @@ public final class Webhooks extends BaseService {
     }
 
     /**
-     * Rotates the signing secret of a webhook. The previous secret stops verifying immediately.
+     * Rotates the signing secret of a webhook. The previous secret keeps working for 24 hours.
      *
      * @param webhookId The unique identifier of the webhook.
      * @return A RotateWebhookSigningSecretResponseSuccess containing the webhook ID and the new signing secret.

--- a/src/main/java/com/resend/services/webhooks/Webhooks.java
+++ b/src/main/java/com/resend/services/webhooks/Webhooks.java
@@ -20,6 +20,7 @@ import com.resend.services.webhooks.model.ListWebhookEventAttemptsResponseSucces
 import com.resend.services.webhooks.model.ListWebhookEventsParams;
 import com.resend.services.webhooks.model.ListWebhookEventsResponseSuccess;
 import com.resend.services.webhooks.model.ReplayWebhookEventResponseSuccess;
+import com.resend.services.webhooks.model.RotateWebhookSigningSecretResponseSuccess;
 import com.resend.services.webhooks.model.VerifyWebhookOptions;
 import okhttp3.MediaType;
 import javax.crypto.Mac;
@@ -202,6 +203,23 @@ public final class Webhooks extends BaseService {
         }
 
         return resendMapper.readValue(response.getBody(), ReplayWebhookEventResponseSuccess.class);
+    }
+
+    /**
+     * Rotates the signing secret of a webhook. The previous secret stops verifying immediately.
+     *
+     * @param webhookId The unique identifier of the webhook.
+     * @return A RotateWebhookSigningSecretResponseSuccess containing the webhook ID and the new signing secret.
+     * @throws ResendException If an error occurs while rotating the signing secret.
+     */
+    public RotateWebhookSigningSecretResponseSuccess rotateSigningSecret(String webhookId) throws ResendException {
+        AbstractHttpResponse<String> response = httpClient.perform("/webhooks/" + webhookId + "/signing-secret/rotate", super.apiKey, HttpMethod.POST, "", MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        return resendMapper.readValue(response.getBody(), RotateWebhookSigningSecretResponseSuccess.class);
     }
 
     /**

--- a/src/main/java/com/resend/services/webhooks/model/RotateWebhookSigningSecretResponseSuccess.java
+++ b/src/main/java/com/resend/services/webhooks/model/RotateWebhookSigningSecretResponseSuccess.java
@@ -1,0 +1,50 @@
+package com.resend.services.webhooks.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a successful response from rotating a webhook signing secret.
+ */
+public class RotateWebhookSigningSecretResponseSuccess {
+    @JsonProperty("object")
+    private String object;
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("signing_secret")
+    private String signingSecret;
+
+    /**
+     * Constructs an empty webhook signing secret rotation response.
+     */
+    public RotateWebhookSigningSecretResponseSuccess() {
+    }
+
+    /**
+     * Gets the object type.
+     *
+     * @return The object type.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * Gets the webhook ID.
+     *
+     * @return The webhook ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the new signing secret for webhook verification.
+     *
+     * @return The signing secret.
+     */
+    public String getSigningSecret() {
+        return signingSecret;
+    }
+}

--- a/src/test/java/com/resend/services/webhooks/WebhooksTest.java
+++ b/src/test/java/com/resend/services/webhooks/WebhooksTest.java
@@ -60,6 +60,9 @@ public class WebhooksTest {
     private static final String REPLAY_WEBHOOK_EVENT_JSON =
             "{\"object\":\"webhook_event\",\"id\":\"" + EVENT_ID + "\"}";
 
+    private static final String ROTATE_WEBHOOK_SIGNING_SECRET_JSON =
+            "{\"object\":\"webhook\",\"id\":\"" + WEBHOOK_ID + "\",\"signing_secret\":\"whsec_rotated_secret\"}";
+
     private static final String LIST_WEBHOOK_EVENT_ATTEMPTS_JSON =
             "{\"object\":\"list\",\"has_more\":false,\"data\":[{\"id\":\"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\"http_status_code\":200,\"response\":\"{\\\"ok\\\":true}\",\"sent_at\":\"2026-08-22T15:33:12.000Z\"}]}";
 
@@ -216,6 +219,20 @@ public class WebhooksTest {
 
         assertEquals("webhook_event", response.getObject());
         assertEquals(EVENT_ID, response.getId());
+    }
+
+    @Test
+    public void testRotateWebhookSigningSecret_Success() throws ResendException {
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(200, ROTATE_WEBHOOK_SIGNING_SECRET_JSON, true);
+
+        when(httpClient.perform(eq("/webhooks/" + WEBHOOK_ID + "/signing-secret/rotate"), anyString(), eq(HttpMethod.POST), eq(""), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        RotateWebhookSigningSecretResponseSuccess response = webhooks.rotateSigningSecret(WEBHOOK_ID);
+
+        assertEquals("webhook", response.getObject());
+        assertEquals(WEBHOOK_ID, response.getId());
+        assertEquals("whsec_rotated_secret", response.getSigningSecret());
     }
 
     @Test


### PR DESCRIPTION
This adds `resend.webhooks().rotateSigningSecret(webhookId)` for `POST /webhooks/{webhook_id}/signing-secret/rotate`, mirroring the event replay method. The response model carries `object`, `id`, and `signing_secret`, the same shape create webhook already returns.

Spec: https://github.com/resend/resend-openapi/pull/113
Linear: https://linear.app/resend/issue/DEV-2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new endpoint to rotate a webhook's signing secret. This lets users replace a compromised secret without recreating the webhook; the previous secret keeps working for 24 hours after rotation.

- Implements the signing secret rotation endpoint from DEV-2079, matching the existing replay event method and returning the same response shape as create webhook.
- Bumps the package version to 4.24.0.

<sup>Written for commit c4faa312ad1bd378eb4864723310216711142f90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-java/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

