### PR TITLE
feat(broadcasts): add duplicate endpoint

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.resend
-VERSION_NAME=4.24.0
+VERSION_NAME=4.25.0
 
 POM_URL=https://github.com/resendlabs/resend-java
 POM_SCM_URL=https://github.com/resendlabs/resend-java.git

--- a/src/main/java/com/resend/services/broadcasts/Broadcasts.java
+++ b/src/main/java/com/resend/services/broadcasts/Broadcasts.java
@@ -105,6 +105,24 @@ public class Broadcasts extends BaseService  {
     }
 
     /**
+     * Duplicates a broadcast into a new draft.
+     *
+     * @param id The unique identifier of the broadcast to duplicate.
+     * @return The DuplicateBroadcastResponseSuccess with the identifier of the new draft.
+     * @throws ResendException If an error occurs during the broadcast duplication process.
+     */
+    public DuplicateBroadcastResponseSuccess duplicate(String id) throws ResendException {
+        AbstractHttpResponse<String> response = httpClient.perform("/broadcasts/" + id + "/duplicate", super.apiKey, HttpMethod.POST, "", MediaType.get("application/json"));
+
+        if (!response.isSuccessful()) {
+            throw new ResendException(response.getCode(), response.getBody());
+        }
+
+        String responseBody = response.getBody();
+        return resendMapper.readValue(responseBody, DuplicateBroadcastResponseSuccess.class);
+    }
+
+    /**
      * Deletes a broadcast based on the provided broadcast ID.
      *
      * @param id The unique identifier of the broadcast to delete.

--- a/src/main/java/com/resend/services/broadcasts/model/DuplicateBroadcastResponseSuccess.java
+++ b/src/main/java/com/resend/services/broadcasts/model/DuplicateBroadcastResponseSuccess.java
@@ -1,0 +1,39 @@
+package com.resend.services.broadcasts.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the response for a successful broadcast duplication.
+ * Extends the BaseBroadcastResponse class.
+ */
+public class DuplicateBroadcastResponseSuccess extends BaseBroadcastResponse {
+    @JsonProperty("object")
+    private String object;
+
+    /**
+     * Default constructor
+     */
+    public DuplicateBroadcastResponseSuccess() {
+
+    }
+
+    /**
+     * Constructs a successful response for duplicating a broadcast.
+     *
+     * @param id        The ID of the new draft broadcast.
+     * @param object    The object of the broadcast.
+     */
+    public DuplicateBroadcastResponseSuccess(String id, String object) {
+        super(id);
+        this.object = object;
+    }
+
+    /**
+     * Get the object.
+     *
+     * @return The type of the data.
+     */
+    public String getObject() {
+        return object;
+    }
+}

--- a/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
+++ b/src/test/java/com/resend/services/broadcasts/BroadcastsTest.java
@@ -45,6 +45,11 @@ public class BroadcastsTest {
     private static final String CANCEL_RESPONSE_JSON =
             "{\"id\":\"" + GET_BROADCAST_ID + "\",\"object\":\"broadcast\"}";
 
+    private static final String DUPLICATED_BROADCAST_ID = "a1e7c2d4-5b3f-4e8a-9c1d-2f6b7a8e9d01";
+
+    private static final String DUPLICATE_RESPONSE_JSON =
+            "{\"id\":\"" + DUPLICATED_BROADCAST_ID + "\",\"object\":\"broadcast\"}";
+
     private static final String LIST_RESPONSE_JSON =
             "{\"object\":\"list\",\"has_more\":true,\"data\":[" +
             "{\"id\":\"1\",\"audience_id\":\"" + AUDIENCE_ID + "\",\"status\":\"draft\",\"created_at\":\"2024-12-01 19:32:22.98+00\"}," +
@@ -178,6 +183,20 @@ public class BroadcastsTest {
 
         assertNotNull(response);
         assertEquals(GET_BROADCAST_ID, response.getId());
+        assertEquals("broadcast", response.getObject());
+    }
+
+    @Test
+    public void testDuplicateBroadcast_Success() throws ResendException {
+        AbstractHttpResponse<String> httpResponse = new AbstractHttpResponse<>(201, DUPLICATE_RESPONSE_JSON, true);
+
+        when(httpClient.perform(eq("/broadcasts/" + GET_BROADCAST_ID + "/duplicate"), anyString(), eq(HttpMethod.POST), eq(""), any(MediaType.class)))
+                .thenReturn(httpResponse);
+
+        DuplicateBroadcastResponseSuccess response = broadcasts.duplicate(GET_BROADCAST_ID);
+
+        assertNotNull(response);
+        assertEquals(DUPLICATED_BROADCAST_ID, response.getId());
         assertEquals("broadcast", response.getObject());
     }
 


### PR DESCRIPTION
Ports `resend.broadcasts.duplicate(id)` from the Node SDK: `Broadcasts.duplicate(String id)` posts to `/broadcasts/{id}/duplicate`, the endpoint added in resend/resend-openapi#115, and returns a `DuplicateBroadcastResponseSuccess` carrying the id of the new draft. The method matches `Templates.duplicate` and `Automations.duplicate`; the response type follows the broadcasts package and extends `BaseBroadcastResponse` like `CancelBroadcastResponseSuccess` instead of being a flat DTO like theirs. The release carries 4.25.0.

Staging call through `Broadcasts.duplicate` from the 4.25.0 jar in Maven local. `HttpClient.BASE_API` is a hardcoded constant, so the call went through a `HttpClient` subclass with `perform` overridden to hit `https://api.resend-staging.com`; the copy was deleted afterwards.

```
source id: e6bd3843-3cc7-4c0d-b7fd-e01cbb514a16
getObject(): broadcast
getId():     8adc9b5a-65ff-43c5-b0b5-f4517912927f
id differs from source: true
```

Left open on purpose: `object` is now duplicated across `CancelBroadcastResponseSuccess`, `RemoveBroadcastResponseSuccess`, and `DuplicateBroadcastResponseSuccess` and could be hoisted into `BaseBroadcastResponse`. That touches the sibling models, so it stays out of this single-endpoint port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Broadcasts.duplicate(id)` to the Java SDK, matching the Node SDK's `resend.broadcasts.duplicate` and the endpoint from resend/resend-openapi#115.

The new method posts to `/broadcasts/{id}/duplicate` and returns a `DuplicateBroadcastResponseSuccess` with the new draft's ID. The version bumps to 4.25.0.

**Refactors**
- `object` is now duplicated across `CancelBroadcastResponseSuccess`, `RemoveBroadcastResponseSuccess`, and `DuplicateBroadcastResponseSuccess`; hoisting it into `BaseBroadcastResponse` is left for a future PR to keep this change focused.

<sup>Written for commit 291c2f152b996ff61b520c433d0494d30e4beabb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-java/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

